### PR TITLE
Allow different error e-mails to not be blocked

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -299,10 +299,9 @@ final class Debugger
 		}
 
 		self::$logger->log(array(
-			@date('[Y-m-d H-i-s]'),
-			trim($message),
-			self::$source ? ' @  ' . self::$source : NULL,
-			$exceptionFilename ? ' @@  ' . basename($exceptionFilename) : NULL
+			'message' => trim($message),
+			'source'  => self::$source ? self::$source : NULL,
+			'detail'  => $exceptionFilename ? basename($exceptionFilename) : NULL
 		), $priority);
 
 		return $exceptionFilename ? strtr($exceptionFilename, '\\/', DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR) : NULL;

--- a/tests/Tracy/Debugger.log().phpt
+++ b/tests/Tracy/Debugger.log().phpt
@@ -30,7 +30,7 @@ class TestLogger
 
 	public function log($message)
 	{
-		Assert::match($this->pattern, $message[1]);
+		Assert::match($this->pattern, $message['message']);
 	}
 }
 

--- a/tests/Tracy/Debugger.logging.error.phpt
+++ b/tests/Tracy/Debugger.logging.error.phpt
@@ -7,13 +7,10 @@
  * @package    Tracy
  */
 
+
 use Tracy\Debugger;
 
-
-
 require __DIR__ . '/../bootstrap.php';
-
-
 
 // Setup environment
 $_SERVER['HTTP_HOST'] = 'nette.org';
@@ -27,8 +24,11 @@ Debugger::enable(Debugger::PRODUCTION, NULL, 'admin@example.com');
 function testMailer() {}
 
 Debugger::$onFatalError[] = function() {
-	Assert::match('%a%Fatal error: Call to undefined function missing_funcion() in %a%', file_get_contents(Debugger::$logDirectory . '/error.log'));
-	Assert::true(is_file(Debugger::$logDirectory . '/email-sent'));
+	$contents = trim(@file_get_contents(Debugger::$logDirectory . '/error.log'));
+
+	Assert::match('Fatal error: Call to undefined function missing_funcion() in %a%', $contents);
+	Assert::true(is_file(Debugger::$logDirectory . '/email-sent-' . md5($contents)));
+
 	die(0);
 };
 ob_start();

--- a/tests/Tracy/Debugger.logging.warnings.phpt
+++ b/tests/Tracy/Debugger.logging.warnings.phpt
@@ -30,5 +30,8 @@ function testMailer() {}
 // throw error
 $a++;
 
-Assert::match('%a%PHP Notice: Undefined variable: a in %a%', file_get_contents($logDirectory . '/error.log'));
-Assert::true(is_file($logDirectory . '/email-sent'));
+
+$contents = trim(@file_get_contents($logDirectory . '/error.log'));
+
+Assert::match('PHP Notice: Undefined variable: a in %a%', $contents);
+Assert::true(is_file($logDirectory . '/email-sent-' . md5($contents)));


### PR DESCRIPTION
This allows errors with unique text, file, and line to not be prevented from being e-mailed by another error.  For example, if there is a missing variable on one page which causes an e-mail sent to get created at 3:00pm and your database goes down and starts throwing exceptions at 3:30 (or even within 2 days I believe by default), then you don't get the much more serious one if you ignore the less serious one for a little bit of time.

This fixes that.

Tests were modified and run to match appropriate changes and I did a more manual test with my actual e-mail and a bogus script erroring to make sure it actually did as it should.