### PR TITLE
fix text align

### DIFF
--- a/src/Tracy/templates/dumper.css
+++ b/src/Tracy/templates/dumper.css
@@ -27,6 +27,7 @@
 
 /* dump */
 pre.tracy-dump {
+	text-align: left;
 	color: #444;
 	background: white;
 }


### PR DESCRIPTION
When we have layout with ' body style="text-align: center" '. Tracy dumps data also aligned centered. This small fix ensures that the text will still be aligned left.
