### PR TITLE
External links set as noreferrer

### DIFF
--- a/src/Tracy/templates/bluescreen.phtml
+++ b/src/Tracy/templates/bluescreen.phtml
@@ -47,7 +47,7 @@ $counter = 0;
 		<div id="tracyBluescreenError" class="panel">
 			<h1><?php echo htmlspecialchars($title), ($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
 
-			<p><?php echo htmlspecialchars($exception->getMessage(), ENT_IGNORE) ?> <a href="https://www.google.com/search?sourceid=tracy&amp;q=<?php echo urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>" id="tracyBsSearch">search&#x25ba;</a></p>
+			<p><?php echo htmlspecialchars($exception->getMessage(), ENT_IGNORE) ?> <a href="https://www.google.com/search?sourceid=tracy&amp;q=<?php echo urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>" id="tracyBsSearch" rel="noreferrer">search&#x25ba;</a></p>
 		</div>
 
 		<?php if ($prev = $exception->getPrevious()): ?>
@@ -339,7 +339,7 @@ $counter = 0;
 			<?php foreach ($info as $item): ?><li><?php echo htmlSpecialChars($item) ?></li><?php endforeach ?>
 		</ul>
 
-		<div id="tracyLogo"><a href="http://tracy.nette.org"></a></div>
+		<div id="tracyLogo"><a href="http://tracy.nette.org" rel="noreferrer"></a></div>
 	</div>
 </div>
 

--- a/tests/Tracy/Debugger.E_ERROR.html.expect
+++ b/tests/Tracy/Debugger.E_ERROR.html.expect
@@ -20,7 +20,7 @@ Fatal error: Call to undefined function missing_function() in %a% on line %d%
 		<div id="tracyBluescreenError" class="panel">
 			<h1>Fatal Error</h1>
 
-			<p>Call to undefined function missing_function() <a href="%a%" id="tracyBsSearch">search&#x25ba;</a></p>
+			<p>Call to undefined function missing_function() <a href="%a%" id="tracyBsSearch" rel="noreferrer">search&#x25ba;</a></p>
 		</div>
 
 
@@ -125,7 +125,7 @@ Fatal error: Call to undefined function missing_function() in %a% on line %d%
 							<li>CLI%a?%</li>
 						<li>PHP %a%</li>		</ul>
 
-		<div id="tracyLogo"><a href="http://tracy.nette.org"></a></div>
+		<div id="tracyLogo"><a href="http://tracy.nette.org" rel="noreferrer"></a></div>
 	</div>
 </div>
 

--- a/tests/Tracy/Debugger.error-in-eval.expect
+++ b/tests/Tracy/Debugger.error-in-eval.expect
@@ -18,7 +18,7 @@
 		<div id="tracyBluescreenError" class="panel">
 			<h1>User Error</h1>
 
-			<p>The my error <a href="%a%" id="tracyBsSearch">search&#x25ba;</a></p>
+			<p>The my error <a href="%a%" id="tracyBsSearch" rel="noreferrer">search&#x25ba;</a></p>
 		</div>
 
 
@@ -185,7 +185,7 @@
 							<li>CLI%a?%</li>
 						<li>PHP %a%</li>		</ul>
 
-		<div id="tracyLogo"><a href="http://tracy.nette.org"></a></div>
+		<div id="tracyLogo"><a href="http://tracy.nette.org" rel="noreferrer"></a></div>
 	</div>
 </div>
 

--- a/tests/Tracy/Debugger.exception.html.expect
+++ b/tests/Tracy/Debugger.exception.html.expect
@@ -18,7 +18,7 @@
 		<div id="tracyBluescreenError" class="panel">
 			<h1>Exception #123</h1>
 
-			<p>The my exception <a href="%a%" id="tracyBsSearch">search&#x25ba;</a></p>
+			<p>The my exception <a href="%a%" id="tracyBsSearch" rel="noreferrer">search&#x25ba;</a></p>
 		</div>
 
 
@@ -181,7 +181,7 @@
 							<li>CLI%a?%</li>
 						<li>PHP %a%</li>		</ul>
 
-		<div id="tracyLogo"><a href="http://tracy.nette.org"></a></div>
+		<div id="tracyLogo"><a href="http://tracy.nette.org" rel="noreferrer"></a></div>
 	</div>
 </div>
 

--- a/tests/Tracy/Debugger.strict.html.expect
+++ b/tests/Tracy/Debugger.strict.html.expect
@@ -18,7 +18,7 @@
 		<div id="tracyBluescreenError" class="panel">
 			<h1>Notice</h1>
 
-			<p>Undefined variable: x <a href="%a%" id="tracyBsSearch">search&#x25ba;</a></p>
+			<p>Undefined variable: x <a href="%a%" id="tracyBsSearch" rel="noreferrer">search&#x25ba;</a></p>
 		</div>
 
 
@@ -188,7 +188,7 @@
 							<li>CLI%a?%</li>
 						<li>PHP %a%</li>		</ul>
 
-		<div id="tracyLogo"><a href="http://tracy.nette.org"></a></div>
+		<div id="tracyLogo"><a href="http://tracy.nette.org" rel="noreferrer"></a></div>
 	</div>
 </div>
 


### PR DESCRIPTION
- Security by default (per browser support)

Prevent leaking HTTP site locations via referrer. _Or spamming them with developer hostnames. Depends on your POW._

Maybe consider using http://no-ref.appspot.com/ or some anonymizer for HTTP sites?
_I did some research and have not found anonymizer backed by trustworthy and independent party (more than just one user, company or organization with no history and provable focus on privacy). Maybe you will have more luck or create one._
