### PR TITLE
Tracy\Dumper:toHtml($instance) should print class location 

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -84,7 +84,7 @@ class Dumper
 		$loc = & $options[self::LOCATION];
 		$loc = $loc === TRUE ? ~0 : (int) $loc;
 
-		if ($loc && self::LOCATION_FROM_REFLECTION && is_object($var)) {
+		if ($loc && $options[self::LOCATION_FROM_REFLECTION] && is_object($var)) {
 			$reflection = new \ReflectionClass($var);
 			$file = $reflection->getFileName();
 			$line = $reflection->getStartLine();


### PR DESCRIPTION
...instead of "called from" location

It is impossible to barDump() class instance with info, where class is located

This improve will allow this

btw maybe you should rather update method findLocation() and add new optional parameter
findLocation($instance = null)

If $instance is set - return array($reflection->getFileName(), $reflection->getStartLine(), $reflection->getStartLine())
