### PR TITLE
Add charset to header for _exceptionHandler

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -401,6 +401,9 @@ class Debugger
 			$protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.1';
 			$code = isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE ') !== FALSE ? 503 : 500;
 			header("$protocol $code", TRUE, $code);
+			if (self::isHtmlMode()) {
+				header('Content-Type: text/html; charset=UTF-8');
+			}
 		}
 
 		try {


### PR DESCRIPTION
Some servers are not run with default_charset=UTF-8. Since UTF-8 characters are used in Tracy, I figured this would be a good change.
