### PR TITLE
BlueScreen - added z-index

### DIFF
--- a/src/Tracy/templates/bluescreen.css
+++ b/src/Tracy/templates/bluescreen.css
@@ -14,6 +14,7 @@ html {
 	background: white;
 	color: #333;
 	position: absolute;
+	z-index: 16777271;
 	left: 0;
 	top: 0;
 	width: 100%;


### PR DESCRIPTION
because I'm using fullscreen loading on my page I've got this "blue screen" (my loading layer has z-index: 100)

![screen shot 2014-07-08 at 16 07 31](https://cloud.githubusercontent.com/assets/42802/3524464/6025d23e-0768-11e4-8633-b67ea56959ba.png)

when I add z index property to blue screen, I've got the blue screen back 

![screen shot 2014-07-08 at 16 08 24](https://cloud.githubusercontent.com/assets/42802/3524491/c5969702-0768-11e4-919d-2e9d71eabbeb.png)

I added z index value to 16777271 because http://www.puidokas.com/max-z-index/

And sorry for missing test, I don't know how to test it with Nette Tester :-)
