### PR TITLE
BlueScreen: added z-index

### DIFF
--- a/src/Tracy/templates/bluescreen.css
+++ b/src/Tracy/templates/bluescreen.css
@@ -55,7 +55,6 @@ html {
 	position: absolute;
 	right: .5em;
 	top: .5em;
-	z-index: 20000;
 	text-decoration: none;
 	background: #CD1818;
 	color: white !important;


### PR DESCRIPTION
Added z-index for BlueScreen.

Test: https://github.com/chemix/sandbox/commits/bluescreen_z_index

Tracy bar, and popup panels is now visible when BlueScreen is opened 
