### PR TITLE
Added exporter for __PHP_Incomplete_Class

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -56,6 +56,7 @@ class Dumper
 		'Closure' => 'Tracy\Dumper::exportClosure',
 		'SplFileInfo' => 'Tracy\Dumper::exportSplFileInfo',
 		'SplObjectStorage' => 'Tracy\Dumper::exportSplObjectStorage',
+		'__PHP_Incomplete_Class' => 'Tracy\Dumper::exportPhpIncompleteClass',
 	);
 
 	/** @var array  */
@@ -465,6 +466,27 @@ class Dumper
 			$res[] = array('object' => $item, 'data' => $obj[$item]);
 		}
 		return $res;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	private static function exportPhpIncompleteClass(\__PHP_Incomplete_Class $obj)
+	{
+		$info = array('className' => NULL, 'private' => array(), 'protected' => array(), 'public' => array());
+		foreach ((array) $obj as $name => $value) {
+			if ($name === '__PHP_Incomplete_Class_Name') {
+				$info['className'] = $value;
+			} elseif (preg_match('#^\x0\*\x0(.+)\z#', $name, $m)) {
+				$info['protected'][$m[1]] = $value;
+			} elseif (preg_match('#^\x0(.+)\x0(.+)\z#', $name, $m)) {
+				$info['private'][$m[1] . '::$' . $m[2]] = $value;
+			} else {
+				$info['public'][$name] = $value;
+			}
+		}
+		return $info;
 	}
 
 

--- a/tests/Tracy/Dumper.objectExporters.phpt
+++ b/tests/Tracy/Dumper.objectExporters.phpt
@@ -30,3 +30,19 @@ Assert::match( 'stdClass #%a%
    x => 2
 ', Dumper::toText($obj, array(Dumper::OBJECT_EXPORTERS => $exporters))
 );
+
+
+$obj = unserialize('O:1:"Y":7:{s:1:"a";N;s:1:"b";i:2;s:4:"' . "\0" . '*' . "\0" . 'c";N;s:4:"' . "\0" . '*' . "\0" . 'd";s:1:"d";s:4:"' . "\0" . 'Y' . "\0" . 'e";N;s:4:"' . "\0" . 'Y' . "\0" . 'i";s:3:"bar";s:4:"' . "\0" . 'X' . "\0" . 'i";s:3:"foo";}');
+
+Assert::match( '__PHP_Incomplete_Class #%a%
+   className => "Y"
+   private => array (3)
+   |  "Y::$e" => NULL
+   |  "Y::$i" => "bar" (3)
+   |  "X::$i" => "foo" (3)
+   protected => array (2)
+   |  c => NULL
+   |  d => "d"
+   public => array (2)
+   |  a => NULL
+   |  b => 2', Dumper::toText($obj) );


### PR DESCRIPTION
More readable variant of output for __PHP_Incomplete_Class.

Before:
![php-incomplete-class-old](https://cloud.githubusercontent.com/assets/144181/4295985/19c3da3e-3df0-11e4-87ef-dd759ef2d9d1.png)

After:
![php-incomplete-class](https://cloud.githubusercontent.com/assets/144181/4295957/c3e565ec-3def-11e4-9f79-06da85182af8.png)
