### PR TITLE
Added exception panel

### DIFF
--- a/src/Tracy/templates/bluescreen.phtml
+++ b/src/Tracy/templates/bluescreen.phtml
@@ -96,6 +96,14 @@ $counter = 0;
 			} ?>
 
 			<div class="panel">
+				<h2><a href="#tracyBsPnl<?php echo ++$counter ?>" class="tracy-toggle tracy-collapsed">Exception</a></h2>
+			
+				<div id="tracyBsPnl<?php echo $counter ?>" class="tracy-collapsed inner">
+					<?php echo Dumper::toHtml($ex) ?>
+				</div>
+			</div>
+
+			<div class="panel">
 			<h2><a href="#tracyBsPnl<?php echo ++$counter ?>" class="tracy-toggle<?php echo ($collapsed = $expanded !== NULL) ? ' tracy-collapsed' : '' ?>">Source file</a></h2>
 
 			<div id="tracyBsPnl<?php echo $counter ?>" class="<?php echo $collapsed ? 'tracy-collapsed ' : '' ?>inner">


### PR DESCRIPTION
When exception is thrown and rendered by Tracy, the actual exception object is not dumped anywhere. However it might hold some additional information useful when the exception is catched and/or for debugging (other than code, message and previous).

I use such exceptions pretty often. For example when a latte template is not found the message only contains the first file from the array that was searched. I use a custom exception that holds the entire array of possible files.

Unfortunately I'm not sure how to fix the tests.
