### PR TITLE
No output in production mode

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -238,8 +238,8 @@ class Debugger
 			$error = isset($e) ? $logMsg : NULL;
 			if (self::isHtmlMode()) {
 				require __DIR__ . '/templates/error.phtml';
-			} else {
-				echo "ERROR: application encountered an error and can not continue.\n$error\n";
+			} elseif (PHP_SAPI === 'cli') {
+				fwrite(STDERR, "ERROR: application encountered an error and can not continue.\n$error\n");
 			}
 
 		} elseif (!connection_aborted() && self::isHtmlMode()) {

--- a/tests/Tracy/Debugger.E_ERROR.production.console.phpt
+++ b/tests/Tracy/Debugger.E_ERROR.production.console.phpt
@@ -4,7 +4,7 @@
  * Test: Tracy\Debugger E_ERROR in production & console mode.
  * @exitCode   255
  * @httpCode   500
- * @outputMatch ERROR:%A%
+ * @outputMatch
  */
 
 use Tracy\Debugger,

--- a/tests/Tracy/Debugger.enable().error.production.console.phpt
+++ b/tests/Tracy/Debugger.enable().error.production.console.phpt
@@ -4,7 +4,7 @@
  * Test: Tracy\Debugger::enable() error.
  * @exitCode   254
  * @httpCode   500
- * @outputMatch ERROR: application encountered an error and can not continue.
+ * @outputMatch 
  */
 
 use Tracy\Debugger;

--- a/tests/Tracy/Debugger.exception.production.console.phpt
+++ b/tests/Tracy/Debugger.exception.production.console.phpt
@@ -4,7 +4,7 @@
  * Test: Tracy\Debugger exception in production & console mode.
  * @exitCode   254
  * @httpCode   500
- * @outputMatch ERROR:%A%
+ * @outputMatch 
  */
 
 use Tracy\Debugger,

--- a/tests/Tracy/Debugger.exceptionHandler.production.console.phpt
+++ b/tests/Tracy/Debugger.exceptionHandler.production.console.phpt
@@ -4,7 +4,7 @@
  * Test: Tracy\Debugger::exceptionHandler() error.
  * @exitCode   254
  * @httpCode   500
- * @outputMatch ERROR: application encountered an error and can not continue.%A%Unable to log error. Check if directory is writable and path is absolute.
+ * @outputMatch 
  */
 
 use Tracy\Debugger;

--- a/tests/Tracy/Debugger.logging.error.phpt
+++ b/tests/Tracy/Debugger.logging.error.phpt
@@ -4,7 +4,7 @@
  * Test: Tracy\Debugger error logging.
  * @exitCode   255
  * @httpCode   500
- * @outputMatch %A%OK!
+ * @outputMatch %A?%OK!
  */
 
 use Tracy\Debugger,


### PR DESCRIPTION
Logging error in production mode is enough. Outputing message about error in non-html content types only breaks validity of json, xml, etc. responses.
