### PR TITLE
Debugger: Move test if directory was set from Debugger to Logger

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -498,9 +498,7 @@ class Debugger
 	 */
 	public static function log($message, $priority = ILogger::INFO)
 	{
-		if (self::getLogger()->directory) {
-			return self::getLogger()->log($message, $priority);
-		}
+		return self::getLogger()->log($message, $priority);
 	}
 
 

--- a/src/Tracy/Logger.php
+++ b/src/Tracy/Logger.php
@@ -50,6 +50,10 @@ class Logger implements ILogger
 	 */
 	public function log($message, $priority = self::INFO)
 	{
+		if (empty($this->directory)) {
+			return NULL;
+		}
+
 		if (!is_dir($this->directory)) {
 			throw new \RuntimeException("Directory '$this->directory' is not found or is not directory.");
 		}


### PR DESCRIPTION
Because we have public interface ILogger, it's make sense test directory in Logger, not Debugger
