### PR TITLE
Fixed nonbreakable space in CSS

### DIFF
--- a/src/Tracy/templates/bluescreen.css
+++ b/src/Tracy/templates/bluescreen.css
@@ -248,12 +248,12 @@ html.tracy-js #tracyBluescreen .tracy-toggle.tracy-collapsed {
 }
 
 #tracyBluescreen .tracy-toggle:after {
-	content: " ▼";
+	content: "\00a0▼";
 	opacity: .4;
 }
 
 #tracyBluescreen .tracy-toggle.tracy-collapsed:after {
-	content: " ►";
+	content: "\00a0►";
 	opacity: .4;
 }
 

--- a/src/Tracy/templates/dumper.css
+++ b/src/Tracy/templates/dumper.css
@@ -16,12 +16,12 @@
 }
 
 .tracy-toggle:after {
-	content: " ▼";
+	content: "\00a0▼";
 	opacity: .4;
 }
 
 .tracy-toggle.tracy-collapsed:after {
-	content: " ►";
+	content: "\00a0►";
 }
 
 


### PR DESCRIPTION
I've upgraded Nette on one of my project and I noticed some weird question marks in tracy dumps (see screenshot below). I've already seen a bug report with this several months ago but can't find it now. Anyway it seems it's not fixed yet.

![bug](https://cloud.githubusercontent.com/assets/539462/5061684/bca7c0ea-6da1-11e4-8f3c-d38a7a21506d.png)
