### PR TITLE
Logger: Added REMOTE_ADDR

### DIFF
--- a/src/Tracy/Logger.php
+++ b/src/Tracy/Logger.php
@@ -100,7 +100,12 @@ class Logger implements ILogger
 	 */
 	protected function formatLogLine($message, $exceptionFile = NULL)
 	{
+		$addr = isset($_SERVER['REMOTE_ADDR'])
+			? $_SERVER['REMOTE_ADDR']
+			: php_uname('n');
+
 		return implode(' ', array(
+			$addr,
 			@date('[Y-m-d H-i-s]'),
 			preg_replace('#\s*\r?\n\s*#', ' ', $this->formatMessage($message)),
 			' @  ' . Helpers::getSource(),

--- a/tests/Tracy/Logger.extensible.phpt
+++ b/tests/Tracy/Logger.extensible.phpt
@@ -41,7 +41,7 @@ test(function() {
 
 	Assert::match('a', $logger->collector[0][0]);
 	Assert::match('Exception: First in %a%:%d%', $logger->collector[0][1]);
-	Assert::match('[%a%] Exception: First in %a%:%d%  @  CLI: %a%  @@  exception-%a%.html', $logger->collector[0][2]);
+	Assert::match(php_uname('n') . ' [%a%] Exception: First in %a%:%d%  @  CLI: %a%  @@  exception-%a%.html', $logger->collector[0][2]);
 	Assert::match('%a%%ds%exception-%a%.html', $logger->collector[0][3]);
 });
 
@@ -51,6 +51,6 @@ test(function() {
 
 	Assert::match('b', $logger->collector[0][0]);
 	Assert::match('message', $logger->collector[0][1]);
-	Assert::match('[%a%] message  @  CLI: %a%', $logger->collector[0][2]);
+	Assert::match(php_uname('n') . ' [%a%] message  @  CLI: %a%', $logger->collector[0][2]);
 	Assert::null($logger->collector[0][3]);
 });

--- a/tests/Tracy/Logger.log().phpt
+++ b/tests/Tracy/Logger.log().phpt
@@ -15,7 +15,7 @@ test(function() {
 	$e = new Exception('First');
 	$logger = new Logger(TEMP_DIR);
 	$logger->log($e, 'a');
-	Assert::match('[%a%] Exception: First in %a%:%d% %A%', file_get_contents($logger->directory . '/a.log'));
+	Assert::match(php_uname('n') . ' [%a%] Exception: First in %a%:%d% %A%', file_get_contents($logger->directory . '/a.log'));
 });
 
 test(function() {
@@ -24,5 +24,5 @@ test(function() {
 	$e = new RuntimeException('Third', 0, $e);
 	$logger = new Logger(TEMP_DIR);
 	$logger->log($e, 'b');
-	Assert::match('[%a%] RuntimeException: Third in %a%:%d% caused by InvalidArgumentException: Second in %a%:%d% caused by Exception: First in %a%:%d% %A%', file_get_contents($logger->directory . '/b.log'));
+	Assert::match(php_uname('n') . ' [%a%] RuntimeException: Third in %a%:%d% caused by InvalidArgumentException: Second in %a%:%d% caused by Exception: First in %a%:%d% %A%', file_get_contents($logger->directory . '/b.log'));
 });


### PR DESCRIPTION
I would like to know a remote address, when I see into log files like log/access.log. Of course, I can go to logs from nginx/apache server and find them but this is a faster way. 