### PR TITLE
added fromEmail option to set From header

### DIFF
--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -19,6 +19,7 @@ class TracyExtension extends Nette\DI\CompilerExtension
 {
 	public $defaults = array(
 		'email' => NULL,
+		'fromEmail' => NULL,
 		'logSeverity' => NULL,
 		'editor' => NULL,
 		'browser' => NULL,

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -132,7 +132,7 @@ class Debugger
 	 * @param  string  sender email; in 'From' header when sending email
 	 * @return void
 	 */
-	public static function enable($mode = NULL, $logDirectory = NULL, $email = NULL, $fromEmail = NULL)
+	public static function enable($mode = NULL, $logDirectory = NULL, $email = NULL)
 	{
 		self::$time = isset($_SERVER['REQUEST_TIME_FLOAT']) ? $_SERVER['REQUEST_TIME_FLOAT'] : microtime(TRUE);
 		error_reporting(E_ALL | E_STRICT);
@@ -144,9 +144,6 @@ class Debugger
 		// logging configuration
 		if ($email !== NULL) {
 			self::$email = $email;
-		}
-		if ($fromEmail !== NULL) {
-			self::$fromEmail = $fromEmail;
 		}
 		if ($logDirectory !== NULL) {
 			self::$logDirectory = $logDirectory;
@@ -407,7 +404,7 @@ class Debugger
 	public static function getLogger()
 	{
 		if (!self::$logger) {
-			self::$logger = new Logger(self::$logDirectory, self::$email, self::getBlueScreen(), self::$fromEmail);
+			self::$logger = new Logger(self::$logDirectory, self::$email, self::getBlueScreen());
 			self::$logger->directory = & self::$logDirectory; // back compatiblity
 			self::$logger->email = & self::$email;
 			self::$logger->fromEmail = & self::$fromEmail;

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -71,7 +71,7 @@ class Debugger
 
 	/** @var string|array email(s) to which send error notifications */
 	public static $email;
-	
+
 	/** @var string email from which send error notifications */
 	public static $fromEmail;
 

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -71,6 +71,9 @@ class Debugger
 
 	/** @var string|array email(s) to which send error notifications */
 	public static $email;
+	
+	/** @var string email from which send error notifications */
+	public static $fromEmail;
 
 	/** {@link Debugger::log()} and {@link Debugger::fireLog()} */
 	const DEBUG = ILogger::DEBUG,
@@ -126,9 +129,10 @@ class Debugger
 	 * @param  mixed   production, development mode, autodetection or IP address(es) whitelist.
 	 * @param  string  error log directory
 	 * @param  string  administrator email; enables email sending in production mode
+	 * @param  string  sender email; in 'From' header when sending email
 	 * @return void
 	 */
-	public static function enable($mode = NULL, $logDirectory = NULL, $email = NULL)
+	public static function enable($mode = NULL, $logDirectory = NULL, $email = NULL, $fromEmail = NULL)
 	{
 		self::$time = isset($_SERVER['REQUEST_TIME_FLOAT']) ? $_SERVER['REQUEST_TIME_FLOAT'] : microtime(TRUE);
 		error_reporting(E_ALL | E_STRICT);
@@ -140,6 +144,9 @@ class Debugger
 		// logging configuration
 		if ($email !== NULL) {
 			self::$email = $email;
+		}
+		if ($fromEmail !== NULL) {
+			self::$fromEmail = $fromEmail;
 		}
 		if ($logDirectory !== NULL) {
 			self::$logDirectory = $logDirectory;
@@ -400,9 +407,10 @@ class Debugger
 	public static function getLogger()
 	{
 		if (!self::$logger) {
-			self::$logger = new Logger(self::$logDirectory, self::$email, self::getBlueScreen());
+			self::$logger = new Logger(self::$logDirectory, self::$email, self::getBlueScreen(), self::$fromEmail);
 			self::$logger->directory = & self::$logDirectory; // back compatiblity
 			self::$logger->email = & self::$email;
+			self::$logger->fromEmail = & self::$fromEmail;
 		}
 		return self::$logger;
 	}

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -129,7 +129,6 @@ class Debugger
 	 * @param  mixed   production, development mode, autodetection or IP address(es) whitelist.
 	 * @param  string  error log directory
 	 * @param  string  administrator email; enables email sending in production mode
-	 * @param  string  sender email; in 'From' header when sending email
 	 * @return void
 	 */
 	public static function enable($mode = NULL, $logDirectory = NULL, $email = NULL)

--- a/src/Tracy/Logger.php
+++ b/src/Tracy/Logger.php
@@ -36,11 +36,10 @@ class Logger implements ILogger
 	private $blueScreen;
 
 
-	public function __construct($directory, $email = NULL, BlueScreen $blueScreen = NULL, $fromEmail = NULL)
+	public function __construct($directory, $email = NULL, BlueScreen $blueScreen = NULL)
 	{
 		$this->directory = $directory;
 		$this->email = $email;
-		$this->fromEmail = $fromEmail;
 		$this->blueScreen = $blueScreen;
 		$this->mailer = array($this, 'defaultMailer');
 	}
@@ -167,7 +166,7 @@ class Logger implements ILogger
 			&& @filemtime($this->directory . '/email-sent') + $snooze < time() // @ - file may not exist
 			&& @file_put_contents($this->directory . '/email-sent', 'sent') // @ - file may not be writable
 		) {
-			call_user_func($this->mailer, $message, implode(', ', (array) $this->email), $this->fromEmail);
+			call_user_func($this->mailer, $message, implode(', ', (array) $this->email));
 		}
 	}
 
@@ -179,10 +178,10 @@ class Logger implements ILogger
 	 * @return void
 	 * @internal
 	 */
-	public function defaultMailer($message, $email, $fromEmail)
+	public function defaultMailer($message, $email)
 	{
 		$host = preg_replace('#[^\w.-]+#', '', isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : php_uname('n'));
-		$fromEmail = ($fromEmail) ? $fromEmail : "noreply@$host";
+		$fromEmail = $this->fromEmail ? $this->fromEmail : "noreply@$host";
 		$parts = str_replace(
 			array("\r\n", "\n"),
 			array("\n", PHP_EOL),

--- a/src/Tracy/Logger.php
+++ b/src/Tracy/Logger.php
@@ -22,7 +22,7 @@ class Logger implements ILogger
 
 	/** @var string|array email or emails to which send error notifications */
 	public $email;
-	
+
 	/** @var string email from which send error notifications */
 	public $fromEmail;
 


### PR DESCRIPTION
Useful for hosting where From email headers in php mail() are
restricted to concrete ones. Can be configured through neon.

- feature
- documentation - needed
- BC break - no