### PR TITLE
BlueScreen: collapse paths usable with files

### DIFF
--- a/src/Tracy/BlueScreen.php
+++ b/src/Tracy/BlueScreen.php
@@ -177,8 +177,10 @@ class BlueScreen
 	 */
 	public function isCollapsed($file)
 	{
+		$file = strtr($file, '\\', '/');
 		foreach ($this->collapsePaths as $path) {
-			if (strpos(strtr($file, '\\', '/'), strtr("$path/", '\\', '/')) === 0) {
+			$path = strtr($path, '\\', '/');
+			if ($file === $path || strncmp($file, "$path/", strlen($path) + 1) === 0) {
 				return TRUE;
 			}
 		}

--- a/tests/Tracy/Bluescreen.collapsedPaths.phpt
+++ b/tests/Tracy/Bluescreen.collapsedPaths.phpt
@@ -13,6 +13,10 @@ require __DIR__ . '/../bootstrap.php';
 $blueScreen = new Tracy\BlueScreen;
 
 $blueScreen->collapsePaths[] = __DIR__;
+$blueScreen->collapsePaths[] = dirname(__DIR__) . '/bootstrap.php';
 
 Assert::true($blueScreen->isCollapsed(__FILE__));
+Assert::true($blueScreen->isCollapsed(dirname(__DIR__) . '/bootstrap.php'));
+Assert::false($blueScreen->isCollapsed(dirname(__DIR__) . '/bootstrap.php.tmp'));
 Assert::false($blueScreen->isCollapsed(dirname(__DIR__) . 'somethingElse'));
+Assert::false($blueScreen->isCollapsed(__DIR__ . '-dir'));


### PR DESCRIPTION
Right now there is possibility to configure collapsed paths in BlueScreen with `BlueScreen::$collapsePaths`. Since the name of the property contains "paths" I think all paths should be allowed.

But because in the implementation a `/` is added at the end, file paths never match. Adding `/` at the end is fine (actually necessary, because otherwise there will be false positives for dirs - I have added a test for this). With files there is of course similar issue with false positives, so matching must be done "exactly" (not starts with).

So implementations for dirs and files must differ and I've not come up with a different solution (without an API change) other than checking the actual given path if it is a file or directory. I hope that should not be a problem.