### PR TITLE
Allow more secured debug mode defined by hash of secret in cookie

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -25,6 +25,7 @@ class Debugger
 		DETECT = NULL;
 
 	const COOKIE_SECRET = 'tracy-debug';
+	const COOKIE_SECRET_SHA = 'tracy-debug-sha';
 
 	/** @var bool in production mode is suppressed any debugging output */
 	public static $productionMode = self::DETECT;
@@ -524,9 +525,12 @@ class Debugger
 		$addr = isset($_SERVER['REMOTE_ADDR'])
 			? $_SERVER['REMOTE_ADDR']
 			: php_uname('n');
+		$secretSha = isset($_COOKIE[self::COOKIE_SECRET_SHA]) && is_string($_COOKIE[self::COOKIE_SECRET_SHA])
+			? sha1($_COOKIE[self::COOKIE_SECRET_SHA])
+			: NULL;
 		$secret = isset($_COOKIE[self::COOKIE_SECRET]) && is_string($_COOKIE[self::COOKIE_SECRET])
 			? $_COOKIE[self::COOKIE_SECRET]
-			: NULL;
+			: $secretSha;
 		$list = is_string($list)
 			? preg_split('#[,\s]+#', $list)
 			: (array) $list;
@@ -534,7 +538,9 @@ class Debugger
 			$list[] = '127.0.0.1';
 			$list[] = '::1';
 		}
-		return in_array($addr, $list, TRUE) || in_array("$secret@$addr", $list, TRUE);
+		return in_array($addr, $list, TRUE)
+			|| in_array("$secret@$addr", $list, TRUE)
+			|| in_array("$secretSha@$addr@sha", $list, TRUE);
 	}
 
 }

--- a/tests/Tracy/Debugger.detectDebugMode.phpt
+++ b/tests/Tracy/Debugger.detectDebugMode.phpt
@@ -70,8 +70,26 @@ test(function () { // secret
 	Assert::false(Debugger::detectDebugMode('abc@192.168.1.1'));
 	Assert::true(Debugger::detectDebugMode('*secret*@192.168.1.1'));
 
-	$_COOKIE[Debugger::COOKIE_SECRET] = ['*secret*'];
+	$_COOKIE[Debugger::COOKIE_SECRET] = ['17fbf884a396643b9e297e8ee6bf2a587c00baf9'];
+	Assert::false(Debugger::detectDebugMode('17fbf884a396643b9e297e8ee6bf2a587c00baf9@192.168.1.1@sha'));
+});
+
+
+test(function () { // secret
+	unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+	$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
+	$_COOKIE[Debugger::COOKIE_SECRET_SHA] = '*secret*';
+
+	Assert::false(Debugger::detectDebugMode());
+	Assert::true(Debugger::detectDebugMode('192.168.1.1'));
+	Assert::false(Debugger::detectDebugMode('abc@192.168.1.1'));
 	Assert::false(Debugger::detectDebugMode('*secret*@192.168.1.1'));
+	Assert::false(Debugger::detectDebugMode('*secret*@192.168.1.1@sha'));
+	Assert::true(Debugger::detectDebugMode('17fbf884a396643b9e297e8ee6bf2a587c00baf9@192.168.1.1'));
+	Assert::true(Debugger::detectDebugMode('17fbf884a396643b9e297e8ee6bf2a587c00baf9@192.168.1.1@sha'));
+
+	$_COOKIE[Debugger::COOKIE_SECRET_SHA] = ['*secret*'];
+	Assert::false(Debugger::detectDebugMode('17fbf884a396643b9e297e8ee6bf2a587c00baf9@192.168.1.1@sha'));
 });
 
 


### PR DESCRIPTION
[CZ] Tracy debug mode switcher v cookie je naprosto super nástroj na okamžité ladění chyb i na produkci.

Ve větších firmách, kde je více lidí v jedné kancelářské budově (= v subnetu) a v projektu, na kterém pracuje více lidí, včetně testerů, je takový klíč tak trochu sdíleným tajemstvím a obtížně se pak odebírá konkrétní osobě přístup.

Tedy předpokládá se, že se toto použije na produkci a deploy kódu lze provést jen přes repo.

Tento pull umožňuje do kódu uložit hash, přičemž do cookie se pak nastavuje původní klíč. Díky tomu může mít každý vývojář vlastní klíč.

V bootstrapu pak může být voláno:
```php
$configurator->setDebugMode([
	'17fbf884a396643b9e297e8ee6bf2a587c00baf9@100.200.123.32@sha', //user1 in office1
	'dd20d63ec7833eef7cc118c90774b5a724856797@100.200.123.32@sha', //user2 in office1
	'bba65c8785652e128dfcf77318905718eb772e7e@100.200.123.32@sha', //user3 in office1
	'bba65c8785652e128dfcf77318905718eb772e7e@123.123.1.1@sha', //user3 in office2
]);
```
přičemž každý uživatel bude míž předělení jiný klíč, např: `*sectret*`, `*sectret2*` a `*sectret3*`. Tyto klíče pak budou posílat v cookie nazvané `tracy-debug-sha` namísto `tracy-debug`.

Aby někdo, kdo zjistí v kódu `secret` nemohl aktivovat debug mód prostým zadáním hashe do cookie, je možné vynutit toto doplněním postfixu `@sha` do listu, tedy tvar je:
> `hash` @ `ip_adresa` @ sha.

Pokud nebude `@sha` do listu doplněn, je na uživateli, jaký způsob si zvolí.