### PR TITLE
Panel: add xdebug version to info panel

### DIFF
--- a/src/Tracy/assets/Bar/info.panel.phtml
+++ b/src/Tracy/assets/Bar/info.panel.phtml
@@ -21,6 +21,7 @@ $info = array_filter([
 	'Server IP' => isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : NULL,
 	'HHVM' => defined('HHVM_VERSION') ? HHVM_VERSION : NULL,
 	'PHP' => PHP_VERSION,
+	'Xdebug' => extension_loaded('xdebug') ? phpversion('xdebug') : NULL,
 	'Tracy' => Debugger::VERSION,
 	'Server' => isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : NULL,
 ] + (array) $this->data);


### PR DESCRIPTION
Helps to identify if xdebug is trully loaded, which also affects the speed of application.

![snimek obrazovky porizeny 2016-01-09 17 28 43](https://cloud.githubusercontent.com/assets/158625/12217115/767d34de-b6f6-11e5-8e3e-f067570f185e.png)
