### PR TITLE
Dumper: use __debugInfo if present by default to export object

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -22,7 +22,8 @@ class Dumper
 		COLLAPSE_COUNT = 'collapsecount', // how big array/object are collapsed? (defaults to 7)
 		LOCATION = 'location', // show location string? (defaults to 0)
 		OBJECT_EXPORTERS = 'exporters', // custom exporters for objects (defaults to Dumper::$objectexporters)
-		LIVE = 'live'; // will be rendered using JavaScript
+		LIVE = 'live', // will be rendered using JavaScript
+		DEBUGINFO = 'debuginfo'; // use magic method __debugInfo if exists (defaults to true)
 
 	const
 		LOCATION_SOURCE = 0b0001, // shows where dump was called
@@ -94,6 +95,7 @@ class Dumper
 			self::COLLAPSE => 14,
 			self::COLLAPSE_COUNT => 7,
 			self::OBJECT_EXPORTERS => NULL,
+			self::DEBUGINFO => TRUE,
 		];
 		$loc = & $options[self::LOCATION];
 		$loc = $loc === TRUE ? ~0 : (int) $loc;
@@ -227,7 +229,7 @@ class Dumper
 
 	private static function dumpObject(& $var, $options, $level)
 	{
-		$fields = self::exportObject($var, $options[self::OBJECT_EXPORTERS]);
+		$fields = self::exportObject($var, $options[self::OBJECT_EXPORTERS], $options[self::DEBUGINFO]);
 		$editor = NULL;
 		if ($options[self::LOCATION] & self::LOCATION_CLASS) {
 			$rc = $var instanceof \Closure ? new \ReflectionFunction($var) : new \ReflectionClass($var);
@@ -348,7 +350,7 @@ class Dumper
 				$obj['level'] = $level;
 				$obj['items'] = [];
 
-				foreach (self::exportObject($var, $options[self::OBJECT_EXPORTERS]) as $k => $v) {
+				foreach (self::exportObject($var, $options[self::OBJECT_EXPORTERS], $options[self::DEBUGINFO]) as $k => $v) {
 					$vis = 0;
 					if ($k[0] === "\x00") {
 						$vis = $k[1] === '*' ? 1 : 2;
@@ -437,13 +439,18 @@ class Dumper
 	/**
 	 * @return array
 	 */
-	private static function exportObject($obj, array $exporters)
+	private static function exportObject($obj, array $exporters, $useDebugInfo)
 	{
 		foreach ($exporters as $type => $dumper) {
 			if ($obj instanceof $type) {
 				return call_user_func($dumper, $obj);
 			}
 		}
+
+		if ($useDebugInfo && method_exists($obj, '__debugInfo')) {
+			return $obj->__debugInfo();
+		}
+
 		return (array) $obj;
 	}
 

--- a/tests/Tracy/Dumper.debugInfo.phpt
+++ b/tests/Tracy/Dumper.debugInfo.phpt
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Test: Tracy\Dumper __debugInfo()
+ */
+
+use Tracy\Dumper;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Password
+{
+	public $password;
+	public $extra = 'foo';
+
+	public function __debugInfo()
+	{
+		return [
+			'password' => '[censored]',
+		];
+	}
+}
+
+
+$obj = new Password;
+$obj->password = 'secret';
+
+
+Assert::match('Password #%a%
+   password => "[censored]" (10)', Dumper::toText($obj));
+
+
+Assert::match('Password #%a%
+   password => "secret" (6)
+   extra => "foo" (3)
+', Dumper::toText($obj, [Dumper::DEBUGINFO => FALSE])
+);
+
+
+$container = new stdClass;
+$container->passwordObject = $obj;
+
+
+Assert::match('stdClass #%a%
+   passwordObject => Password #%a%
+   |  password => "[censored]" (10)
+', Dumper::toText($container));
+
+
+Assert::match('stdClass #%a%
+   passwordObject => Password #%a%
+   |  password => "secret" (6)
+   |  extra => "foo" (3)
+', Dumper::toText($container, [Dumper::DEBUGINFO => FALSE]));


### PR DESCRIPTION
This is resurrection of https://github.com/nette/nette/pull/1415.

Tests are added.

I've also added possibility to switch this off with `Dumper::DEBUGINFO => FALSE`. I've chosen `TRUE` as default because it feels to me not only as new feature, but rather matching default behavior of PHP. <del>Last point: I've enabled it only for PHP >=5.6 where this magic method is actually supported by PHP.</del>