### PR TITLE
Pass array for $args to formatHtml

### DIFF
--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -26,15 +26,15 @@ class Helpers
 				$file = '...' . $m[0];
 			}
 			$file = strtr($file, '/', DIRECTORY_SEPARATOR);
-			return self::formatHtml('<a href="%" title="%">%<b>%</b>%</a>',
+			return self::formatHtml('<a href="%" title="%">%<b>%</b>%</a>', array(
 				$editor,
 				$file . ($line ? ":$line" : ''),
 				rtrim(dirname($file), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR,
 				basename($file),
 				$line ? ":$line" : ''
-			);
+			));
 		} else {
-			return self::formatHtml('<span>%</span>', $file . ($line ? ":$line" : ''));
+			return self::formatHtml('<span>%</span>', array($file . ($line ? ":$line" : '')));
 		}
 	}
 


### PR DESCRIPTION
Method `self::formatHtml` from `Tracy\Helpers` was invoked incorrectly.
This was causing PHP Warning: `Variable passed to each() is not an array or object` and due to this the errors list was incomplete:

Before:
![tracy_errors](https://cloud.githubusercontent.com/assets/422571/13091406/491ead9c-d4fb-11e5-887c-af256b8bc6e4.png)

After fix:
![tracy_errors_fixed](https://cloud.githubusercontent.com/assets/422571/13091452/a0f0c0dc-d4fb-11e5-9b11-e6a96f9db58a.png)
