### PR TITLE
Feature Request: Add last error panel to bluescreen

### DIFF
--- a/src/Tracy/BlueScreen.php
+++ b/src/Tracy/BlueScreen.php
@@ -95,6 +95,8 @@ class BlueScreen
 		$skipError = $sourceIsUrl && $exception instanceof \ErrorException && !empty($exception->skippable)
 			? $source . (strpos($source, '?') ? '&' : '?') . '_tracy_skip_error'
 			: NULL;
+		$lastError = (!$exception instanceof \ErrorException) ? error_get_last() : NULL;
+
 		require $template;
 	}
 

--- a/src/Tracy/assets/BlueScreen/content.phtml
+++ b/src/Tracy/assets/BlueScreen/content.phtml
@@ -174,6 +174,23 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 		<?php endif ?>
 
 
+		<?php if ($lastError): ?>
+		<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Last error</a></h2>
+		<div class="tracy-collapsed inner">
+
+		<h3><?= Helpers::errorTypeToString($lastError['type']) ?>: <?= htmlspecialchars($lastError['message'], ENT_IGNORE, 'UTF-8') ?></h3>
+		<?php if (isset($lastError['file']) && is_file($lastError['file'])): ?>
+			<p><?= Helpers::editorLink($lastError['file'], $lastError['line']) ?> <a data-tracy-ref="^+" class="tracy-toggle">source</a>&nbsp;</p>
+			<div><?= self::highlightFile($lastError['file'], $lastError['line']) ?></div>
+		<?php else: ?>
+			<p><i>inner-code</i><?php if (isset($lastError['line'])) echo ':', $lastError['line'] ?></p>
+		<?php endif ?>
+
+		</div></div>
+		<?php endif ?>
+
+
 		<?php $bottomPanels = [] ?>
 		<?php foreach ($panels as $panel): ?>
 		<?php $panel = call_user_func($panel, NULL); if (empty($panel['tab']) || empty($panel['panel'])) continue; ?>

--- a/tests/Tracy/Debugger.E_ERROR.html.expect
+++ b/tests/Tracy/Debugger.E_ERROR.html.expect
@@ -50,7 +50,7 @@
 </span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>    }
 <span class='line'>%d%:</span>
 <span class='line'>%d%:</span>
-<span class='line'>%d%:</span>    </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">10</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #080">'any string'</span><span style="color: #D24; font-weight: bold">);
+<span class='line'>%d%:</span>    echo @</span><span style="color: #000">$undefined</span><span style="color: #D24; font-weight: bold">;
 </span></span></code></div></pre>			</div></div>
 
 
@@ -119,8 +119,7 @@
 					first(<a data-tracy-ref="^p + .args" class="tracy-toggle tracy-collapsed">arguments</a>)
 					</p>
 
-											<div class="tracy-collapsed file"><pre data-tracy-href="%a%" class='code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>        </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">([</span><span style="color: #000">1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">2</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">3</span><span style="color: #D24; font-weight: bold">]);
-<span class='line'>%d%:</span>    }
+											<div class="tracy-collapsed file"><pre data-tracy-href="%a%" class='code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>    }
 <span class='line'>%d%:</span>
 <span class='line'>%d%:</span>
 <span class='line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
@@ -129,6 +128,7 @@
 <span class='line'>%d%:</span>    }
 <span class='line'>%d%:</span>
 <span class='line'>%d%:</span>
+<span class='line'>%d%:</span>    echo @</span><span style="color: #000">$undefined</span><span style="color: #D24; font-weight: bold">;
 <span class='highlight'>%d%:    first(10, 'any string');
 </span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>    </span>
 </span></code></div></pre></div>
@@ -152,6 +152,30 @@
 
 
 
+
+
+				<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Last error</a></h2>
+		<div class="tracy-collapsed inner">
+
+		<h3>Notice: Undefined variable: undefined</h3>
+					<p><a href="editor%a%" title="%a%Debugger.E_ERROR.html.phpt:%d%">%a%<b>Debugger.E_ERROR.html.phpt</b>:%d%</a> <a data-tracy-ref="^+" class="tracy-toggle">source</a>&nbsp;</p>
+			<div><pre data-tracy-href="editor%a%" class='code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='line'>53:</span>        </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">([</span><span style="color: #000">1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">2</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">3</span><span style="color: #D24; font-weight: bold">]);
+<span class='line'>%d%:</span>    }
+<span class='line'>%d%:</span>
+<span class='line'>%d%:</span>
+<span class='line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
+<span class='line'>%d%:</span>    {
+<span class='line'>%d%:</span>        </span><span style="color: #000">missing_function</span><span style="color: #D24; font-weight: bold">();
+<span class='line'>%d%:</span>    }
+<span class='line'>%d%:</span>
+<span class='line'>%d%:</span>
+<span class='highlight'>%d%:    echo @$undefined;
+</span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>    </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">10</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #080">'any string'</span><span style="color: #D24; font-weight: bold">);
+<span class='line'>%d%:</span>    </span>
+</span></code></div></pre></div>
+
+		</div></div>
 
 
 

--- a/tests/Tracy/Debugger.E_ERROR.html.php5.expect
+++ b/tests/Tracy/Debugger.E_ERROR.html.php5.expect
@@ -52,7 +52,7 @@ Fatal error: Call to undefined function missing_function() in %a% on line %d%
 </span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>    }
 <span class='line'>%d%:</span>
 <span class='line'>%d%:</span>
-<span class='line'>%d%:</span>    </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">10</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #080">'any string'</span><span style="color: #D24; font-weight: bold">);
+<span class='line'>%d%:</span>    echo @</span><span style="color: #000">$undefined</span><span style="color: #D24; font-weight: bold">;
 </span></span></code></div></pre>			</div></div>
 
 
@@ -65,6 +65,35 @@ Fatal error: Call to undefined function missing_function() in %a% on line %d%
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Exception</a></h2>
 		<div class="tracy-collapsed inner">
 		<pre class="tracy-dump" data-tracy-dump='{"object":"01"}'></pre>
+		</div></div>
+
+
+
+
+
+
+
+				<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Last error</a></h2>
+		<div class="tracy-collapsed inner">
+
+		<h3>Notice: Undefined variable: undefined</h3>
+					<p><a href="editor%a%" title="%a%Debugger.E_ERROR.html.phpt:%d%">%a%<b>Debugger.E_ERROR.html.phpt</b>:%d%</a> <a data-tracy-ref="^+" class="tracy-toggle">source</a>&nbsp;</p>
+			<div><pre data-tracy-href="editor%a%" class='code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='line'>53:</span>        </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">([</span><span style="color: #000">1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">2</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">3</span><span style="color: #D24; font-weight: bold">]);
+<span class='line'>%d%:</span>    }
+<span class='line'>%d%:</span>
+<span class='line'>%d%:</span>
+<span class='line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
+<span class='line'>%d%:</span>    {
+<span class='line'>%d%:</span>        </span><span style="color: #000">missing_function</span><span style="color: #D24; font-weight: bold">();
+<span class='line'>%d%:</span>    }
+<span class='line'>%d%:</span>
+<span class='line'>%d%:</span>
+<span class='highlight'>%d%:    echo @$undefined;
+</span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='line'>%d%:</span>    </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">10</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #080">'any string'</span><span style="color: #D24; font-weight: bold">);
+<span class='line'>%d%:</span>    </span>
+</span></code></div></pre></div>
+
 		</div></div>
 
 

--- a/tests/Tracy/Debugger.E_ERROR.html.phpt
+++ b/tests/Tracy/Debugger.E_ERROR.html.phpt
@@ -60,4 +60,5 @@ function third($arg1)
 }
 
 
+echo @$undefined;
 first(10, 'any string');

--- a/tests/Tracy/Debugger.error-in-eval.expect
+++ b/tests/Tracy/Debugger.error-in-eval.expect
@@ -125,6 +125,17 @@
 		</div></div>
 
 
+				<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Last error</a></h2>
+		<div class="tracy-collapsed inner">
+
+		<h3>Notice: Undefined variable: undefined</h3>
+					<p><a href="%a%" title="%a%Debugger.error-in-eval.phpt:%d%">%a%<b>Debugger.error-in-eval.phpt</b>:%d%</a> <a data-tracy-ref="^+" class="tracy-toggle">source</a>&nbsp;</p>
+			<div><pre data-tracy-href="%a%Debugger.error-in-eval.phpt&amp;line=%d%" class='code'>%A%</pre></div>
+
+		</div></div>
+
+
 
 
 		<div class="panel">

--- a/tests/Tracy/Debugger.error-in-eval.phpt
+++ b/tests/Tracy/Debugger.error-in-eval.phpt
@@ -29,4 +29,5 @@ function first($user, $pass)
 }
 
 
+echo @$undefined;
 first('root', 'xxx');

--- a/tests/Tracy/Debugger.exception.html.expect
+++ b/tests/Tracy/Debugger.exception.html.expect
@@ -112,6 +112,17 @@
 
 
 
+				<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Last error</a></h2>
+		<div class="tracy-collapsed inner">
+
+		<h3>Notice: Undefined variable: undefined</h3>
+					<p><a href="editor:%a%" title="%a%Debugger.exception.html.phpt:%d%">%a%<b>Debugger.exception.html.phpt</b>:%d%</a> <a data-tracy-ref="^+" class="tracy-toggle">source</a>&nbsp;</p>
+			<div>%A%</div>
+
+		</div></div>
+
+
 
 
 		<div class="panel">

--- a/tests/Tracy/Debugger.exception.html.phpt
+++ b/tests/Tracy/Debugger.exception.html.phpt
@@ -42,5 +42,5 @@ function third($arg1)
 
 
 define('MY_CONST', 123);
-
+echo @$undefined;
 first(10, 'any string');

--- a/tests/Tracy/Debugger.strict.html.expect
+++ b/tests/Tracy/Debugger.strict.html.expect
@@ -128,6 +128,17 @@
 		</div></div>
 
 
+				<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Last error</a></h2>
+		<div class="tracy-collapsed inner">
+
+		<h3>Notice: Undefined variable: undefined</h3>
+					<p><a href="editor:%a%" title="%a%Debugger.strict.html.phpt:%d%">%a%<b>Debugger.strict.html.phpt</b>:%d%</a> <a data-tracy-ref="^+" class="tracy-toggle">source</a>&nbsp;</p>
+			<div>%A%</div>
+
+		</div></div>
+
+
 
 
 		<div class="panel">

--- a/tests/Tracy/Debugger.strict.html.phpt
+++ b/tests/Tracy/Debugger.strict.html.phpt
@@ -41,5 +41,5 @@ function third($arg1)
 	$x++;
 }
 
-
+echo @$undefined;
 first(10, 'any string');


### PR DESCRIPTION
In PHP it is quite common to use "shut-up + escalating error to exception" pattern ([example](https://github.com/nette/utils/blob/9cd7d72e92d613407bf8d336a49225566c748a79/src/Utils/FileSystem.php#L24-L29)). Unfortunately the original error message is lost unless `error_get_last()['message']` is manually appended to exception message.

What about adding a simple panel to bluescreen to show the last error? The error may not always be related. We may attempt to do some magic to filter the relevant error but I'm not sure it's worth it.

---

Related: https://github.com/nette/utils/pull/94