### PR TITLE
The "#tracy-debug *" in barr.css break inline css for new addition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "tracy/tracy",
+	"name": "jcmarchi/tracy",
 	"description": "Tracy: useful PHP debugger",
 	"keywords": ["debug", "debugger", "nette"],
 	"homepage": "https://tracy.nette.org",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "jcmarchi/tracy",
+	"name": "tracy/tracy",
 	"description": "Tracy: useful PHP debugger",
 	"keywords": ["debug", "debugger", "nette"],
 	"homepage": "https://tracy.nette.org",

--- a/src/Tracy/assets/Bar/bar.css
+++ b/src/Tracy/assets/Bar/bar.css
@@ -19,9 +19,16 @@ body #tracy-debug {
 	right: 0;
 }
 
-#tracy-debug * {
+/* #tracy-debug * { */ 
+#tracy-debug[class~='tracy'] *, .tracy-inner *, .tracy-panel *, .tracy-dump * {
 	font: inherit;
+	color: inherit;
+	background: transparent;
+	margin: 0;
+	padding: 0;
 	border: none;
+	text-align: inherit;
+	list-style: inherit;
 	opacity: 1;
 	border-radius: 0;
 	box-shadow: none;

--- a/src/Tracy/assets/Bar/bar.css
+++ b/src/Tracy/assets/Bar/bar.css
@@ -21,13 +21,7 @@ body #tracy-debug {
 
 #tracy-debug * {
 	font: inherit;
-	color: inherit;
-	background: transparent;
-	margin: 0;
-	padding: 0;
 	border: none;
-	text-align: inherit;
-	list-style: inherit;
 	opacity: 1;
 	border-radius: 0;
 	box-shadow: none;


### PR DESCRIPTION
With this CSS rule as it is it becomes very hard to expand Tracy.

With the proposed modification very little visual impact exist while freeing new addition to implement inline CSS on desired elements without Tracy rules affecting it.