### PR TITLE
evalScript: only evaluate *javascript* scripts

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -401,10 +401,12 @@
 
 	function evalScripts(elem) {
 		[].forEach.call(elem.querySelectorAll('script'), function(script) {
-			(window.execScript || function(data) {
-				window['eval'].call(window, data);
-			})(script.innerHTML);
-			script.parentNode.removeChild(script);
+			if (!script.hasAttribute('type') || script.type === 'text/javascript' || script.type === 'application/javascript') {
+				(window.execScript || function (data) {
+					window['eval'].call(window, data);
+				})(script.innerHTML);
+				script.parentNode.removeChild(script);
+			}
 		});
 	};
 


### PR DESCRIPTION
the script tag can be used for other things than javascript - script tags with a different "type" than text/javascript shouldn't be assumed to be javascript