### PR TITLE
Delay panel rendering

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -550,7 +550,7 @@ class Debugger
 		if (!self::$productionMode) {
 			static $panel;
 			if (!$panel) {
-				self::getBar()->addPanel($panel = new DefaultBarPanel('dumps'));
+				self::getBar()->addPanel($panel = new DefaultBarPanel('dumps'), 'Tracy:dumps');
 			}
 			$panel->data[] = ['title' => $title, 'dump' => Dumper::toHtml($var, (array) $options + [
 				Dumper::DEPTH => self::$maxDepth,

--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -22,6 +22,10 @@
 	Panel.prototype.init = function() {
 		var _this = this, elem = this.elem;
 
+		elem.innerHTML = elem.dataset.tracyContent;
+		delete elem.dataset.tracyContent;
+		evalScripts(elem);
+
 		draggable(elem, {
 			handle: elem.querySelector('h1'),
 			stop: function() {
@@ -70,7 +74,6 @@
 		if (!this.is('tracy-ajax')) {
 			Tracy.Toggle.persist(elem);
 		}
-		this.restorePosition();
 	};
 
 	Panel.prototype.is = function(mode) {
@@ -189,8 +192,10 @@
 		if (!pos) {
 			this.elem.classList.add(Panel.PEEK);
 		} else if (pos.window) {
+			this.init();
 			this.toWindow();
-		} else if (this.elem.querySelector('*')) {
+		} else if (this.elem.dataset.tracyContent) {
+			this.init();
 			this.toFloat();
 			setPosition(this.elem, pos);
 		}
@@ -246,6 +251,10 @@
 					var panel = Debug.panels[this.rel], link = this;
 					panel.focus(function() {
 						if (panel.is(Panel.PEEK)) {
+							if (panel.elem.dataset.tracyContent) {
+								panel.init();
+							}
+
 							var pos = getPosition(panel.elem);
 							setPosition(panel.elem, {
 								right: pos.right - getOffset(link).left + pos.width - getPosition(link).width - 4 + getOffset(panel.elem).left,
@@ -301,7 +310,7 @@
 
 		forEach(document.querySelectorAll('.tracy-panel'), function(panel) {
 			Debug.panels[panel.id] = new Panel(panel.id);
-			Debug.panels[panel.id].init();
+			Debug.panels[panel.id].restorePosition();
 		});
 
 		Debug.captureWindow();
@@ -328,7 +337,7 @@
 		forEach(document.querySelectorAll('.tracy-panel'), function(panel) {
 			if (!Debug.panels[panel.id]) {
 				Debug.panels[panel.id] = new Panel(panel.id);
-				Debug.panels[panel.id].init();
+				Debug.panels[panel.id].restorePosition();
 			}
 		});
 

--- a/src/Tracy/assets/Bar/panels.phtml
+++ b/src/Tracy/assets/Bar/panels.phtml
@@ -12,18 +12,19 @@
 namespace Tracy;
 
 use Tracy;
+use Tracy\Helpers;
 
+$icons = <<<'HTML'
+	<div class="tracy-icons">
+		<a href="#" title="open in window">&curren;</a>
+		<a href="#" rel="close" title="close window">&times;</a>
+	</div>
+HTML;
 
 foreach ($rows as $row) {
 	foreach ($row->panels as $panel) {
-?>
-	<div class="tracy-panel <?= $row->type === 'ajax' ? 'tracy-ajax' : '' ?>" id="tracy-debug-panel-<?= $panel->id ?>">
-		<?php if ($panel->panel): echo $panel->panel ?>
-		<div class="tracy-icons">
-			<a href="#" title="open in window">&curren;</a>
-			<a href="#" rel="close" title="close window">&times;</a>
-		</div>
-		<?php endif ?>
-	</div><?php
+		$content = $panel->panel ? ($panel->panel . "\n" . $icons) : '';
+		$class = 'tracy-panel ' . ($row->type === 'ajax' ? 'tracy-ajax' : ''); ?>
+		<div class="<?= $class ?>" id="tracy-debug-panel-<?= $panel->id ?>" data-tracy-content="<?= Helpers::escapeHtml($content) ?>"></div><?php
 	}
 }

--- a/tests/Tracy/Debugger.barDump().expect
+++ b/tests/Tracy/Debugger.barDump().expect
@@ -1,7 +1,11 @@
-%A%<h1>Dumps</h1>
+<style class="tracy-debug">
+	%A%
+</style>
+
+<h1>Dumps</h1>
 
 <div class="tracy-inner tracy-DumpPanel">
-	
+
 	<pre class="tracy-dump" title="barDump($arr)
 in file %a% on line %d%" data-tracy-href="editor:%a%"><span class="tracy-toggle"><span class="tracy-dump-array">array</span> (8)</span>
 <div><span class="tracy-dump-indent">   </span><span class="tracy-dump-key">0</span> => <span class="tracy-dump-number">10</span>
@@ -18,8 +22,13 @@ in file %a% on line %d%" data-tracy-href="editor:%a%"><span class="tracy-toggle"
 <span class="tracy-dump-indent">   |  </span><span class="tracy-dump-key">key2</span> => <span class="tracy-dump-bool">TRUE</span>
 </div></div></pre>
 		<h2>String</h2>
-	
+
 	<pre class="tracy-dump" title="barDump(&#039;&lt;a href=&quot;#&quot;&gt;test&lt;/a&gt;&#039;, &#039;String&#039;)
 in file %a% on line %d%" data-tracy-href="editor:%a%"><span class="tracy-dump-string">"&lt;a href=&quot;#&quot;&gt;test&lt;/a&gt;"</span> (20)
 </pre>
-</div>%A%
+</div>
+
+	<div class="tracy-icons">
+		<a href="#" title="open in window">&curren;</a>
+		<a href="#" rel="close" title="close window">&times;</a>
+	</div>

--- a/tests/Tracy/Debugger.barDump().phpt
+++ b/tests/Tracy/Debugger.barDump().phpt
@@ -5,8 +5,9 @@
  * @outputMatch OK!
  */
 
-use Tracy\Debugger;
 use Tester\Assert;
+use Tester\DomQuery;
+use Tracy\Debugger;
 
 
 require __DIR__ . '/../bootstrap.php';
@@ -26,8 +27,9 @@ Debugger::enable();
 
 register_shutdown_function(function () {
 	ob_end_clean();
-	$content = reset($_SESSION['_tracy']['bar'])['content'];
-	Assert::matchFile(__DIR__ . '/Debugger.barDump().expect', $content);
+	$rawContent = reset($_SESSION['_tracy']['bar'])['content'];
+	$panelContent = (string) DomQuery::fromHtml($rawContent)->find('#tracy-debug-panel-Tracy-dumps')[0]['data-tracy-content'];
+	Assert::matchFile(__DIR__ . '/Debugger.barDump().expect', $panelContent);
 	echo 'OK!'; // prevents PHP bug #62725
 });
 

--- a/tests/Tracy/Debugger.barDump().showLocation.phpt
+++ b/tests/Tracy/Debugger.barDump().showLocation.phpt
@@ -5,8 +5,9 @@
  * @outputMatch OK!
  */
 
-use Tracy\Debugger;
 use Tester\Assert;
+use Tester\DomQuery;
+use Tracy\Debugger;
 
 
 require __DIR__ . '/../bootstrap.php';
@@ -27,7 +28,8 @@ Debugger::enable();
 
 register_shutdown_function(function () {
 	ob_end_clean();
-	$content = reset($_SESSION['_tracy']['bar'])['content'];
+	$rawContent = reset($_SESSION['_tracy']['bar'])['content'];
+	$panelContent = (string) DomQuery::fromHtml($rawContent)->find('#tracy-debug-panel-Tracy-dumps')[0]['data-tracy-content'];
 	Assert::match(<<<EOD
 %A%<h1>Dumps</h1>
 
@@ -39,7 +41,7 @@ in file %a% on line %d%" data-tracy-href="editor:%a%"><span class="tracy-dump-st
 </div>
 %A%
 EOD
-, $content);
+, $panelContent);
 	echo 'OK!'; // prevents PHP bug #62725
 });
 

--- a/tests/Tracy/Debugger.warnings.html.phpt
+++ b/tests/Tracy/Debugger.warnings.html.phpt
@@ -5,8 +5,9 @@
  * @outputMatch OK!
  */
 
-use Tracy\Debugger;
 use Tester\Assert;
+use Tester\DomQuery;
+use Tracy\Debugger;
 
 
 require __DIR__ . '/../bootstrap.php';
@@ -29,7 +30,8 @@ register_shutdown_function(function () {
 	Assert::match('
 Warning: Unsupported declare \'foo\' in %a% on line %d%%A%', $output);
 
-	$content = reset($_SESSION['_tracy']['bar'])['content'];
+	$rawContent = reset($_SESSION['_tracy']['bar'])['content'];
+	$panelContent = (string) DomQuery::fromHtml($rawContent)->find('#tracy-debug-panel-Tracy-errors')[0]['data-tracy-content'];
 	Assert::match('%A%<table>
 <tr>
 	<td class="tracy-right">1%a%</td>
@@ -48,7 +50,7 @@ Warning: Unsupported declare \'foo\' in %a% on line %d%%A%', $output);
 	<td><pre>PHP Warning: %a% in %a%:%d%</a></pre></td>
 </tr>
 </table>
-</div>%A%', $content);
+</div>%A%', $panelContent);
 	echo 'OK!'; // prevents PHP bug #62725
 });
 


### PR DESCRIPTION
Similarly to how we delay rendering of invisible dumps we should delay rendering of invisible panels and render them the first time they became visible. This is especially important when bar panel contains a lot of HTML (for example query log).

What do you think?