### PR TITLE
Tracy does not preserve panel id when moving panel to new window

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -147,7 +147,7 @@
 			+ '<script src="' + escape(document.getElementById('tracy-debug-script').src) + '" onload="Tracy.Dumper.init()" async><\/script>'
 			+ '<body id="tracy-debug">'
 		);
-		doc.body.innerHTML = '<div class="tracy-panel tracy-mode-window">' + this.elem.innerHTML + '<\/div>';
+		doc.body.innerHTML = '<div class="tracy-panel tracy-mode-window" id="' + this.elem.id + '">' + this.elem.innerHTML + '<\/div>';
 		if (this.elem.querySelector('h1')) {
 			doc.title = this.elem.querySelector('h1').innerHTML;
 		}


### PR DESCRIPTION
Current behavior breaks for example [Nextras Mail Panel](https://github.com/nextras/mail-panel/blob/e238dd9d0311f941f3f09433094059b15c49d4f4/src/MailPanel.latte#L1-L40).