### PR TITLE
bar.js: fixed evaluating script tags in panels in window-mode

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -148,6 +148,7 @@
 			+ '<body id="tracy-debug">'
 		);
 		doc.body.innerHTML = '<div class="tracy-panel tracy-mode-window">' + this.elem.innerHTML + '<\/div>';
+		evalScripts(doc.body, win);
 		if (this.elem.querySelector('h1')) {
 			doc.title = this.elem.querySelector('h1').innerHTML;
 		}
@@ -399,13 +400,13 @@
 		document.documentElement.appendChild(Debug.scriptElem);
 	};
 
-	function evalScripts(elem) {
+	function evalScripts(elem, scope) {
+		scope = scope || window;
 		forEach(elem.getElementsByTagName('script'), function(script) {
 			if (!script.hasAttribute('type') || script.type === 'text/javascript' || script.type === 'application/javascript') {
-				(window.execScript || function (data) {
-					window['eval'].call(window, data);
+				(scope.execScript || function (data) {
+					scope['eval'].call(scope, data);
 				})(script.innerHTML);
-				script.parentNode.removeChild(script);
 			}
 		});
 	};


### PR DESCRIPTION
*Still working on certain tracy panel…*

This changes evalScripts to NOT remove the evaluated scripts (which was introduced in https://github.com/nette/tracy/commit/63b03725b1108c8627567512d875c349c2b8689b). This likely breaks some other behavior.