### PR TITLE
Logger: can now report errors by other means than email

### DIFF
--- a/tests/Tracy/Debugger.logging.error2.phpt
+++ b/tests/Tracy/Debugger.logging.error2.phpt
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Test: Tracy\Debugger error logging.
+ * @exitCode   255
+ * @httpCode   500
+ * @outputMatch %A?%OK!
+ */
+
+use Tracy\Debugger;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// Setup environment
+$_SERVER['HTTP_HOST'] = 'nette.org';
+
+Debugger::$logDirectory = TEMP_DIR;
+
+Debugger::getLogger()->addReportChannel(function () {});
+
+ob_start();
+Debugger::enable(Debugger::PRODUCTION);
+
+
+register_shutdown_function(function () {
+	Assert::match('%a%Error: Call to undefined function missing_function() in %a%', file_get_contents(Debugger::$logDirectory . '/exception.log'));
+	Assert::true(is_file(Debugger::$logDirectory . '/email-sent'));
+	echo 'OK!'; // prevents PHP bug #62725
+});
+
+
+missing_function();

--- a/tests/Tracy/Debugger.logging.warnings2.phpt
+++ b/tests/Tracy/Debugger.logging.warnings2.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Tracy\Debugger notices and warnings logging.
+ */
+
+use Tracy\Debugger;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// Setup environment
+$_SERVER['HTTP_HOST'] = 'nette.org';
+
+$logDirectory = TEMP_DIR;
+
+Debugger::getLogger()->addReportChannel(function () {});
+
+Debugger::enable(Debugger::PRODUCTION, $logDirectory);
+
+
+// throw error
+$a++;
+
+Assert::match('%a%PHP Notice: Undefined variable: a in %a%', file_get_contents($logDirectory . '/error.log'));
+Assert::true(is_file($logDirectory . '/email-sent'));


### PR DESCRIPTION
My aim is to be able to report errors via text messages. But idea is to allow any other means for reporting, e.g. create issue in internal reporting system--the advantage would be, that it would contain all the necessary information for future reference.

Possibly in the future, email would lose it's special status because--in the end--it is just another reporting channel, no different from others, mentioned earlier.

If agreed, I suggest traditional slow transition, with:
  1. full backwards compatibility
  2. bc with triggering deprecated warning
  3. release with only new functionality

I'm ready to prepare these steps too.