### PR TITLE
BlueScreen: preserve whitespace in message

### DIFF
--- a/src/Tracy/assets/BlueScreen/bluescreen.css
+++ b/src/Tracy/assets/BlueScreen/bluescreen.css
@@ -92,6 +92,10 @@ html {
 	margin: .7em 0;
 }
 
+#tracy-bs h1 span {
+	white-space: pre;
+}
+
 #tracy-bs h2 {
 	font: 14pt/1.5 sans-serif !important;
 	margin: .6em 0;

--- a/src/Tracy/assets/BlueScreen/bluescreen.phtml
+++ b/src/Tracy/assets/BlueScreen/bluescreen.phtml
@@ -49,7 +49,7 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			<?php if ($exception->getMessage()): ?><p><?= Helpers::escapeHtml($title . $code) ?></p><?php endif ?>
 
 
-			<h1><?= Helpers::escapeHtml($exception->getMessage() ?: $title . $code) ?>
+			<h1><span><?= Helpers::escapeHtml(trim($exception->getMessage() ?: $title . $code)) ?></span>
 			<a href="https://www.google.com/search?sourceid=tracy&amp;q=<?= urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>" target="_blank" rel="noreferrer noopener">search&#x25ba;</a>
 			<?php if ($skipError): ?><a href="<?= Helpers::escapeHtml($skipError) ?>">skip error&#x25ba;</a><?php endif ?></h1>
 		</div>

--- a/tests/Tracy/Debugger.E_ERROR.html.expect
+++ b/tests/Tracy/Debugger.E_ERROR.html.expect
@@ -18,7 +18,8 @@
 		<div id="tracy-bs-error" class="panel">
 			<p>Error</p>
 
-			<h1>Call to undefined function missing_function()			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
+			<h1><span>Call to undefined function missing_function()</span>
+			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
 			</h1>
 		</div>
 

--- a/tests/Tracy/Debugger.E_ERROR.html.php5.expect
+++ b/tests/Tracy/Debugger.E_ERROR.html.php5.expect
@@ -20,7 +20,8 @@ Fatal error: Call to undefined function missing_function() in %a% on line %d%
 		<div id="tracy-bs-error" class="panel">
 			<p>Fatal Error</p>
 
-			<h1>Call to undefined function missing_function()			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
+			<h1><span>Call to undefined function missing_function()</span>
+			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
 			</h1>
 		</div>
 

--- a/tests/Tracy/Debugger.E_ERROR.html.xdebug.expect
+++ b/tests/Tracy/Debugger.E_ERROR.html.xdebug.expect
@@ -20,7 +20,8 @@ Fatal error: Call to undefined function missing_function() in %a% on line %d%
 		<div id="tracy-bs-error" class="panel">
 			<p>Fatal Error</p>
 
-			<h1>Call to undefined function missing_function()			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
+			<h1><span>Call to undefined function missing_function()</span>
+			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
 			</h1>
 		</div>
 

--- a/tests/Tracy/Debugger.error-in-eval.expect
+++ b/tests/Tracy/Debugger.error-in-eval.expect
@@ -18,7 +18,8 @@
 		<div id="tracy-bs-error" class="panel">
 			<p>User Error</p>
 
-			<h1>The my error			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
+			<h1><span>The my error</span>
+			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
 			</h1>
 		</div>
 

--- a/tests/Tracy/Debugger.exception.html.expect
+++ b/tests/Tracy/Debugger.exception.html.expect
@@ -18,7 +18,8 @@
 		<div id="tracy-bs-error" class="panel">
 			<p>Exception #123</p>
 
-			<h1>The my exception			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
+			<h1><span>The my exception</span>
+			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
 			</h1>
 		</div>
 

--- a/tests/Tracy/Debugger.strict.html.expect
+++ b/tests/Tracy/Debugger.strict.html.expect
@@ -18,7 +18,8 @@
 		<div id="tracy-bs-error" class="panel">
 			<p>Notice</p>
 
-			<h1>Undefined variable: x			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
+			<h1><span>Undefined variable: x</span>
+			<a href="%a%" rel="noreferrer noopener">search&#x25ba;</a>
 			</h1>
 		</div>
 


### PR DESCRIPTION
Just an idea. New lines are rarely present in exception messages, but when they do, they usually have a good reason.