### PR TITLE
bar.js: fixed evaluating script tags in panels in window-mode

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -147,6 +147,12 @@
 			doc.title = this.elem.querySelector('h1').innerHTML;
 		}
 
+		for (var i = 0, scripts = doc.body.getElementsByTagName('script'); i < scripts.length; i++) {
+			(win.execScript || function(data) {
+				win['eval'].call(win, data);
+			})(scripts[i].innerHTML);
+		}
+
 		var _this = this;
 		win.addEventListener('beforeunload', function() {
 			_this.toPeek();


### PR DESCRIPTION
I copy pasted the code to avoid refactoring.

---

The broken tests are not caused by this PR.