### PR TITLE
Change editor mapping to support multiple changes to the same substring

### DIFF
--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -20,7 +20,7 @@ class Helpers
 	 */
 	public static function editorLink($file, $line = NULL)
 	{
-		$file = strtr($origFile = $file, Debugger::$editorMapping);
+		$file = self::editorMapping($origFile = $file);
 		if ($editor = self::editorUri($origFile, $line)) {
 			$file = strtr($file, '\\', '/');
 			if (preg_match('#(^[a-z]:)?/.{1,50}$#i', $file, $m) && strlen($file) > strlen($m[0])) {
@@ -47,9 +47,22 @@ class Helpers
 	public static function editorUri($file, $line = NULL)
 	{
 		if (Debugger::$editor && $file && is_file($file)) {
-			$file = strtr($file, Debugger::$editorMapping);
+			$file = self::editorMapping($file);
 			return strtr(Debugger::$editor, ['%file' => rawurlencode($file), '%line' => $line ? (int) $line : 1]);
 		}
+	}
+
+
+	/**
+	 * Modifies link to returned to editor.
+	 * @return string
+	 */
+	public static function editorMapping($file)
+	{
+		foreach (Debugger::$editorMapping as $k => $v) {
+			$file = str_replace($k, $v, $file);
+		}
+		return $file;
 	}
 
 


### PR DESCRIPTION
Sorry, I didn’t think about the scenario of wanting make multiple changes to a substring. Of course strtr fails at this. This version allows these sorts of changes. In my scenario I can now change from the compiled version to the source version, as well as map production server URLs to the local dev source.

Hopefully you are happy with these changes.