### PR TITLE
bar.js: restorePosition does not handle toWindow error

### DIFF
--- a/src/Tracy/assets/Bar/bar.css
+++ b/src/Tracy/assets/Bar/bar.css
@@ -185,6 +185,7 @@ body #tracy-debug {
 
 /* panels */
 #tracy-debug .tracy-panel {
+	display: none;
 	font: normal normal 12px/1.5 sans-serif;
 	background: white;
 	color: #333;

--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -133,7 +133,7 @@
 		var win = window.open('', this.id.replace(/-/g, '_'), 'left=' + offset.left + ',top=' + offset.top
 			+ ',width=' + this.elem.offsetWidth + ',height=' + this.elem.offsetHeight + ',resizable=yes,scrollbars=yes');
 		if (!win) {
-			return;
+			return false;
 		}
 
 		function escape(s) {
@@ -169,6 +169,7 @@
 		this.elem.classList.remove(Panel.PEEK);
 		this.elem.classList.add(Panel.WINDOW);
 		this.elem.Tracy.window = win;
+		return true;
 	};
 
 	Panel.prototype.reposition = function() {
@@ -195,7 +196,7 @@
 			this.elem.classList.add(Panel.PEEK);
 		} else if (pos.window) {
 			this.init();
-			this.toWindow();
+			this.toWindow() || this.toFloat();
 		} else if (this.elem.dataset.tracyContent) {
 			this.init();
 			this.toFloat();


### PR DESCRIPTION
When `toWindow()` failed in `restorePosition`, the panel ended up in an invalid state. This PR resolves this problem in two ways – by making `.tracy-panel` hidden be default and by falling back to `toFloat` when toWindows fails.