### PR TITLE
Fix for a hidden panel content in a new window.

### DIFF
--- a/src/Tracy/assets/Bar/bar.css
+++ b/src/Tracy/assets/Bar/bar.css
@@ -266,6 +266,7 @@ body #tracy-debug {
 
 #tracy-debug .tracy-mode-window {
 	padding: 10px;
+	display: block;
 }
 
 #tracy-debug .tracy-icons a {


### PR DESCRIPTION
Since fe7df9ab3361329225686108339838b4304d50f6 the content of a Tracy panel has been hidden when you put it in a new window.

This css change returns the origin behaviour.