### PR TITLE
ISession added

### DIFF
--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -56,7 +56,7 @@ class Bar
 	 */
 	public function render()
 	{
-		$useSession = $this->dispatched && session_status() === PHP_SESSION_ACTIVE;
+		$useSession = $this->dispatched && Debugger::getSession()->isActive();
 		$redirectQueue = & $_SESSION['_tracy']['redirect'];
 
 		if (!Helpers::isHtmlMode() && !Helpers::isAjax()) {

--- a/src/Tracy/BlueScreen.php
+++ b/src/Tracy/BlueScreen.php
@@ -58,7 +58,7 @@ class BlueScreen
 	 */
 	public function render($exception)
 	{
-		if (Helpers::isAjax() && session_status() === PHP_SESSION_ACTIVE) {
+		if (Helpers::isAjax() && Debugger::getSession()->isActive()) {
 			ob_start(function () {});
 			$this->renderTemplate($exception, __DIR__ . '/assets/BlueScreen/content.phtml');
 			$contentId = $_SERVER['HTTP_X_TRACY_AJAX'];

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -120,6 +120,9 @@ class Debugger
 	/** @var ILogger */
 	private static $fireLogger;
 
+	/** @var ISession */
+	private static $session;
+
 
 	/**
 	 * Static class - cannot be instantiated.
@@ -190,7 +193,7 @@ class Debugger
 
 		if (!self::$productionMode && self::getBar()->dispatchAssets()) {
 			exit;
-		} elseif (session_status() === PHP_SESSION_ACTIVE) {
+		} elseif (self::getSession()->isActive()) {
 			self::dispatch();
 		}
 	}
@@ -204,13 +207,8 @@ class Debugger
 		if (self::$productionMode) {
 			return;
 
-		} elseif (session_status() !== PHP_SESSION_ACTIVE) {
-			ini_set('session.use_cookies', '1');
-			ini_set('session.use_only_cookies', '1');
-			ini_set('session.use_trans_sid', '0');
-			ini_set('session.cookie_path', '/');
-			ini_set('session.cookie_httponly', '1');
-			session_start();
+		} elseif (!self::getSession()->isActive()) {
+			self::getSession()->start();
 		}
 		if (self::getBar()->dispatchContent()) {
 			exit;
@@ -491,6 +489,27 @@ class Debugger
 			self::$fireLogger = new FireLogger;
 		}
 		return self::$fireLogger;
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public static function setSession(ISession $session)
+	{
+		self::$session = $session;
+	}
+
+
+	/**
+	 * @return ISession
+	 */
+	public static function getSession()
+	{
+		if (!self::$session) {
+			self::$session = new DefaultSession();
+		}
+		return self::$session;
 	}
 
 

--- a/src/Tracy/DefaultSession.php
+++ b/src/Tracy/DefaultSession.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the Tracy (https://tracy.nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+namespace Tracy;
+
+class DefaultSession implements ISession
+{
+
+	/**
+	 * @return bool
+	 */
+	public function isActive()
+	{
+		return session_status() === PHP_SESSION_ACTIVE;
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public function start()
+	{
+		ini_set('session.use_cookies', '1');
+		ini_set('session.use_only_cookies', '1');
+		ini_set('session.use_trans_sid', '0');
+		ini_set('session.cookie_path', '/');
+		ini_set('session.cookie_httponly', '1');
+		session_start();
+	}
+
+}

--- a/src/Tracy/ISession.php
+++ b/src/Tracy/ISession.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Tracy (https://tracy.nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+namespace Tracy;
+
+interface ISession
+{
+
+	/**
+	 * @return bool
+	 */
+	public function isActive();
+
+
+	/**
+	 * @return void
+	 */
+	public function start();
+
+}


### PR DESCRIPTION
I run a CLI application in a debug mode (development, CI).

But Tracy v2.4 is starting a session automatically and itselfs: [[1]](https://github.com/nette/tracy/blame/master/src/Bridges/Nette/TracyExtension.php#L101), [[2]](https://github.com/nette/tracy/blame/master/src/Tracy/Debugger.php#L208).

I can't solve this by fake session object. When DI Container is initialized, `session_start()` is called and I do nothing with it.

So I've extracted `session_*` code into `ISession` interface which should allow set custom ISession implementation. It is useful in a CLI when debug mode is enabled.

---

https://forum.nette.org/cs/26250-pojdte-otestovat-nette-2-4-rc?p=3#p175951
http://zlml.cz/fix-compatibility-with-nette-2-4#comment-2740141135