### PR TITLE
Sets CSS to UTF-8 for toggle triangle chars

### DIFF
--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -165,7 +165,7 @@ class Bar
 	{
 		$asset = isset($_GET['_tracy_bar']) ? $_GET['_tracy_bar'] : NULL;
 		if ($asset === 'css') {
-			header('Content-Type: text/css');
+			header('Content-Type: text/css; charset=utf-8');
 			header('Cache-Control: max-age=864000');
 			header_remove('Pragma');
 			header_remove('Set-Cookie');


### PR DESCRIPTION
Explicitly set the CSS to UTF-8 so the toggle triangles display properly on HTML pages that do not declare UTF-8 encoding.

![nette-tracy on non-utf-8](https://cloud.githubusercontent.com/assets/241335/16210326/7157c594-3709-11e6-89f8-adae05100e75.png)
