### PR TITLE
Dumper::encodeString - use mb_substr

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -422,8 +422,8 @@ class Dumper
 			$s = strtr($s, $table);
 
 		} elseif ($maxLength && $s !== '') {
-			if (function_exists('iconv_substr')) {
-				$s = iconv_substr($tmp = $s, 0, $maxLength, 'UTF-8');
+			if (function_exists('mb_substr')) {
+				$s = mb_substr($tmp = $s, 0, $maxLength, 'UTF-8');
 				$shortened = $s !== $tmp;
 			} else {
 				$i = $len = 0;


### PR DESCRIPTION
`iconv_substr` is very f*cking slow. Even the do-while fallback is few thousand times faster :D