### PR TITLE
optimize Dumper::encodeString for long strings

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -428,7 +428,7 @@ class Dumper
 			}
 			$s = strtr($s, $table);
 
-		} elseif ($maxLength && $s !== '' && !function_exists('mb_substr')) {
+		} elseif ($maxLength && strlen($s) > $maxLength && !function_exists('mb_substr')) {
 			$i = $len = 0;
 			do {
 				if (($s[$i] < "\x80" || $s[$i] >= "\xC0") && (++$len > $maxLength)) {

--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -415,26 +415,31 @@ class Dumper
 			$table["\t"] = '\t';
 		}
 
-		if (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
+		if (function_exists('mb_substr')) {
+			if ($maxLength && strlen($s) > $maxLength) {
+				$s = mb_substr($tmp = $s, 0, $maxLength, 'UTF-8');
+				$shortened = $s !== $tmp;
+			} else {
+				$shortened = false;
+			}
+			if (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
+				$s = strtr($s, $table);
+			}
+		} elseif (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
 			if ($shortened = ($maxLength && strlen($s) > $maxLength)) {
 				$s = substr($s, 0, $maxLength);
 			}
 			$s = strtr($s, $table);
 
 		} elseif ($maxLength && $s !== '') {
-			if (function_exists('mb_substr')) {
-				$s = mb_substr($tmp = $s, 0, $maxLength, 'UTF-8');
-				$shortened = $s !== $tmp;
-			} else {
-				$i = $len = 0;
-				do {
-					if (($s[$i] < "\x80" || $s[$i] >= "\xC0") && (++$len > $maxLength)) {
-						$s = substr($s, 0, $i);
-						$shortened = TRUE;
-						break;
-					}
-				} while (isset($s[++$i]));
-			}
+			$i = $len = 0;
+			do {
+				if (($s[$i] < "\x80" || $s[$i] >= "\xC0") && (++$len > $maxLength)) {
+					$s = substr($s, 0, $i);
+					$shortened = TRUE;
+					break;
+				}
+			} while (isset($s[++$i]));
 		}
 
 		return $s . (empty($shortened) ? '' : ' ... ');

--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -415,23 +415,20 @@ class Dumper
 			$table["\t"] = '\t';
 		}
 
-		if (function_exists('mb_substr')) {
+		$shortened = FALSE;
+		if ($maxLength && function_exists('mb_substr') && strlen($s) > $maxLength) {
+			$s = mb_substr($tmp = $s, 0, $maxLength, 'UTF-8');
+			$shortened = $s !== $tmp;
+		}
+
+		if (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
 			if ($maxLength && strlen($s) > $maxLength) {
-				$s = mb_substr($tmp = $s, 0, $maxLength, 'UTF-8');
-				$shortened = $s !== $tmp;
-			} else {
-				$shortened = false;
-			}
-			if (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
-				$s = strtr($s, $table);
-			}
-		} elseif (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
-			if ($shortened = ($maxLength && strlen($s) > $maxLength)) {
 				$s = substr($s, 0, $maxLength);
+				$shortened = TRUE;
 			}
 			$s = strtr($s, $table);
 
-		} elseif ($maxLength && $s !== '') {
+		} elseif ($maxLength && $s !== '' && !function_exists('mb_substr')) {
 			$i = $len = 0;
 			do {
 				if (($s[$i] < "\x80" || $s[$i] >= "\xC0") && (++$len > $maxLength)) {

--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -421,7 +421,7 @@ class Dumper
 			$shortened = $s !== $tmp;
 		}
 
-		if (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s) || preg_last_error()) {
+		if (!preg_match('#^[\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]*+\z#u', $s) || preg_last_error()) {
 			if ($maxLength && strlen($s) > $maxLength) {
 				$s = substr($s, 0, $maxLength);
 				$shortened = TRUE;


### PR DESCRIPTION
- feature
- issues - none
- documentation - not needed
- BC break - yes

The purpose of this PR is to speedup dumping of large strings for reasonable maxLength. The performance problem is in `preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $s)` which scans the whole string. By preferring `mb_substr` it is possible to truncate the string before running it through the regex and thus potentially saving a lot of time for large strings. However this is a slight BC break, because now it won't recognize some binary strings it did recognize before, but since the binary part will be outside the truncated string I think it is worth it.

As you can see from [the benchmark I made](https://gist.github.com/schlndh/e7f3e9c7f98ce8131ef3452b8bb46fb5) the performance impact for short strings or large strings with unlimited maxLength is minimal or none, however the performance gain for long strings with small maxLength is massive.

The benchmark compares current `encodeString` implementation (encodeStringOrig) with implementation from this PR (encodeStringChanged) and just running the `preg_match` on the whole string. The first column (N) is the number of characters and the values of other columns are average times for one call on given string in nanoseconds.

Benchmarking was done on Linux with PHP 7.0.10
