### PR TITLE
Ability to set whether bluescreen panel is collapsed or not

### DIFF
--- a/src/Tracy/assets/BlueScreen/content.phtml
+++ b/src/Tracy/assets/BlueScreen/content.phtml
@@ -193,10 +193,11 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 		<?php $bottomPanels = [] ?>
 		<?php foreach ($this->renderPanels(NULL) as $panel): ?>
 		<?php if (!empty($panel->bottom)) { $bottomPanels[] = $panel; continue; } ?>
+		<?php $collapsedClass = !isset($panel->collapsed) || $panel->collapsed ? ' tracy-collapsed' : ''; ?>
 		<div class="panel">
-			<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed"><?= Helpers::escapeHtml($panel->tab) ?></a></h2>
+			<h2><a data-tracy-ref="^+" class="tracy-toggle<?= $collapsedClass ?>"><?= Helpers::escapeHtml($panel->tab) ?></a></h2>
 
-			<div class="tracy-collapsed inner">
+			<div class="inner<?= $collapsedClass ?>">
 			<?= $panel->panel ?>
 		</div></div>
 		<?php endforeach ?>


### PR DESCRIPTION
Purpose of this pull request is to give user-defined panels in bluescreen possibility to declare whether they want to be collapsed or expanded.

Now, if you implement Bluescreen panel, you must return from your callback array with two keys - `panel` and `tab`. After this PR we will support third optional key - `collapsed`.