### PR TITLE
Avoid multiple init for bar links

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -222,11 +222,12 @@
 
 	Bar.prototype.initTabs = function() {
 		var _this = this, elem = this.elem;
-		
-		if (a.hasAttribute('data-initialized')) return true;
-		a.setAttribute('data-initialized', '');
 
 		forEach(elem.getElementsByTagName('a'), function(a) {
+			
+			if (a.hasAttribute('data-initialized')) return true;
+			a.setAttribute('data-initialized', '');
+			
 			a.addEventListener('click', function(e) {
 				if (this.rel === 'close') {
 					_this.close();

--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -222,6 +222,9 @@
 
 	Bar.prototype.initTabs = function() {
 		var _this = this, elem = this.elem;
+		
+		if (a.hasAttribute('data-initialized')) return true;
+		a.setAttribute('data-initialized', '');
 
 		forEach(elem.getElementsByTagName('a'), function(a) {
 			a.addEventListener('click', function(e) {


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

When the AJAX bar appears, events are re-added for bar links. For example, when clicking on a bar link the corresponding panel appears and disappears because there are two click events on it. This fix adds a data attribute and events are added only if this attribute is not present on the link.
