### PR TITLE
bar.css, bluescreen.css: fixed leaks of page's default CSS into Tracy

### DIFF
--- a/src/Tracy/assets/Bar/bar.css
+++ b/src/Tracy/assets/Bar/bar.css
@@ -34,6 +34,13 @@ body#tracy-debug { /* for popup window */
 	text-shadow: none;
 }
 
+#tracy-debug:before,
+#tracy-debug:after,
+#tracy-debug *:before,
+#tracy-debug *:after {
+	display: none;
+}
+
 #tracy-debug b,
 #tracy-debug strong {
 	font-weight: bold;
@@ -64,6 +71,8 @@ body#tracy-debug { /* for popup window */
 #tracy-debug .tracy-panel h2,
 #tracy-debug .tracy-panel h3,
 #tracy-debug .tracy-panel p {
+	color: #333 !important;
+	background: transparent !important;
 	margin: .4em 0;
 }
 
@@ -195,7 +204,8 @@ body#tracy-debug { /* for popup window */
 
 #tracy-debug h1 {
 	font: normal normal 23px/1.4 Tahoma, sans-serif;
-	color: #575753;
+	color: #575753 !important;
+	background: transparent !important;
 	margin: -5px -5px 5px;
 	padding: 0 25px 0 5px;
 	max-width: 700px;

--- a/src/Tracy/assets/BlueScreen/bluescreen.css
+++ b/src/Tracy/assets/BlueScreen/bluescreen.css
@@ -25,6 +25,13 @@
 	text-indent: 0;
 }
 
+#tracy-bs:before,
+#tracy-bs:after,
+#tracy-bs *:before,
+#tracy-bs *:after {
+	display: none;
+}
+
 #tracy-bs b {
 	font-weight: bold;
 }
@@ -257,11 +264,13 @@ html.tracy-js #tracy-bs .tracy-toggle.tracy-collapsed {
 
 #tracy-bs .tracy-toggle:after {
 	content: " ▼";
+	display: inline;
 	opacity: .4;
 }
 
 #tracy-bs .tracy-toggle.tracy-collapsed:after {
 	content: " ►";
+	display: inline;
 	opacity: .4;
 }
 


### PR DESCRIPTION
- bug fix? yes

I just made Tracy more sexy :) There is [issue opened](https://github.com/nette/tracy/issues/206) that shows headings being affected by CSS property with `!important` set on. I have fixed this particular case (for headings and paragraphs).

Another problem occured on page with styled pseudoelements `:before` or `:after`. On my page, there are styled headings that are decorated by these pseudoelements. Sadly, Tracy rendered these as well and so its layout went broken. Now, after my fixes, any pseudoelements inside Tracy will be hidden by default except cases where it is need for it.