### PR TITLE
Display AJAX bar for Fetch requests

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -395,6 +395,30 @@
 				});
 			}
 		};
+
+		if (window.fetch) {
+			var oldFetch = window.fetch;
+			window.fetch = function(request, options) {
+				options = options || {};
+				options.headers = new Headers(options.headers || {});
+				var url = request instanceof Request ? request.url : request;
+
+				if (window.TracyAutoRefresh !== false && url.indexOf('//') <= 0 || url.indexOf(location.origin + '/') === 0) {
+					options.headers.set('X-Tracy-Ajax', header);
+					options.credentials = (request instanceof Request && request.credentials) || options.credentials || 'same-origin';
+
+					return oldFetch(request, options).then(function (response) {
+						if (response.headers.has('X-Tracy-Ajax') && response.headers.get('X-Tracy-Ajax')[0] === '1') {
+							Debug.loadScript('?_tracy_bar=content-ajax.' + header + '&XDEBUG_SESSION_STOP=1&v=' + Math.random());
+						}
+
+						return response;
+					});
+				}
+
+				return oldFetch(request, options);
+			};
+		}
 	};
 
 	Debug.loadScript = function(url) {


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: doesn't seem necessary

This pull request adds AJAX debug bar support for requests made via [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) instead of `XMLHttpRequest`.

There is one caveat which, however, should imo be addressed in the userland: `fetch()` must be sent with `credentials` set to `include` or `same-origin` for the cookies to be passed and thus for the debug bar session storage to work. This implementation sanely defaults to `same-origin` if the option is not provided, but if the user sends their own `Request` object, the `credentials` option defaults to `omit` if not provided, and cannot be overridden. I believe it should be left up to the user to handle such situations.