### PR TITLE
Show date/time error occurred

### DIFF
--- a/src/Tracy/assets/Debugger/error.500.phtml
+++ b/src/Tracy/assets/Debugger/error.500.phtml
@@ -30,6 +30,7 @@ namespace Tracy;
 		was unable to complete your request. Please try again later.</p>
 
 		<p><small>error 500<?php if (!$logged): ?><br>Tracy is unable to log error.<?php endif ?></small></p>
+		<p><?php echo date('r'); ?></p>
 	</div>
 </div>
 


### PR DESCRIPTION
- bug fix? no  
- new feature? yes
- BC break? no
- doc PR: not applicable

Often i get emailed screenshots of the 500 error page, if it showed the date/time on the page, it would be much easier to find the relevant logs.

This change does not require any additional tests.
