### PR TITLE
make the error handler context argument optional

### DIFF
--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -361,7 +361,7 @@ class Debugger
 	 * @throws ErrorException
 	 * @internal
 	 */
-	public static function errorHandler($severity, $message, $file, $line, $context)
+	public static function errorHandler($severity, $message, $file, $line, $context = array())
 	{
 		if (self::$scream) {
 			error_reporting(E_ALL);

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -361,7 +361,7 @@ class Debugger
 	 * @throws ErrorException
 	 * @internal
 	 */
-	public static function errorHandler($severity, $message, $file, $line, $context = array())
+	public static function errorHandler($severity, $message, $file, $line, $context = [])
 	{
 		if (self::$scream) {
 			error_reporting(E_ALL);


### PR DESCRIPTION
The context argument of an error handler is optional. Furthermore, it will be deprecated in PHP 7.2 (see http://www.php.net/manual/en/function.set-error-handler.php).

- bug fix? yes
- new feature? no
- BC break? no
- doc PR: -

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
