### PR TITLE
Add support for custom css, js, and body strings

### DIFF
--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -244,7 +244,7 @@ class Bar
 			__DIR__ . '/assets/BlueScreen/bluescreen.js',
 		], Debugger::$customJsFiles));
 
-		echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ', Debugger::$customHeadStr)."'; document.head.appendChild(el);})();\n";
-		echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ',Debugger::$customBodyStr)."'; document.body.appendChild(el);})();\n";
+		if(Debugger::$customHeadStr) echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ', Debugger::$customHeadStr)."'; document.head.appendChild(el);})();\n";
+		if(Debugger::$customBodyStr) echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ',Debugger::$customBodyStr)."'; document.body.appendChild(el);})();\n";
 	}
 }

--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -243,5 +243,8 @@ class Bar
 			__DIR__ . '/assets/Dumper/dumper.js',
 			__DIR__ . '/assets/BlueScreen/bluescreen.js',
 		], Debugger::$customJsFiles));
+
+		echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ', Debugger::$customHeadStr)."'; document.head.appendChild(el);})();\n";
+		echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ',Debugger::$customBodyStr)."'; document.body.appendChild(el);})();\n";
 	}
 }

--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -237,6 +237,8 @@ class Bar
 		$css = json_encode(preg_replace('#\s+#u', ' ', implode($css)));
 		echo "(function(){var el = document.createElement('style'); el.className='tracy-debug'; el.textContent=$css; document.head.appendChild(el);})();\n";
 
+		if(Debugger::$customCssStr) echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ', Debugger::$customCssStr)."'; document.head.appendChild(el);})();\n";
+
 		array_map('readfile', array_merge([
 			__DIR__ . '/assets/Bar/bar.js',
 			__DIR__ . '/assets/Toggle/toggle.js',
@@ -244,7 +246,8 @@ class Bar
 			__DIR__ . '/assets/BlueScreen/bluescreen.js',
 		], Debugger::$customJsFiles));
 
-		if(Debugger::$customHeadStr) echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ', Debugger::$customHeadStr)."'; document.head.appendChild(el);})();\n";
-		if(Debugger::$customBodyStr) echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ',Debugger::$customBodyStr)."'; document.body.appendChild(el);})();\n";
+		if(Debugger::$customJsStr) echo Debugger::$customJsStr;
+
+		if(Debugger::$customBodyStr) echo "(function(){var el = document.createElement('div'); el.className='tracy-debug'; el.innerHTML='".preg_replace('#\s+#u', ' ', Debugger::$customBodyStr)."'; document.body.appendChild(el);})();\n";
 	}
 }

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -110,10 +110,10 @@ class Debugger
 	public static $customJsFiles = [];
 
 	/** @var string */
-	public static $customHeadStr;
+	public static $customHeadStr = null;
 
 	/** @var string */
-	public static $customBodyStr;
+	public static $customBodyStr = null;
 
 	/** @var array */
 	private static $cpuUsage;

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -103,11 +103,17 @@ class Debugger
 	/** @var string custom static error template */
 	public static $errorTemplate;
 
-	/** @var string[] */
+	/** @var array[] */
 	public static $customCssFiles = [];
 
-	/** @var string[] */
+	/** @var array[] */
 	public static $customJsFiles = [];
+
+	/** @var string */
+	public static $customHeadStr;
+
+	/** @var string */
+	public static $customBodyStr;
 
 	/** @var array */
 	private static $cpuUsage;

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -110,7 +110,10 @@ class Debugger
 	public static $customJsFiles = [];
 
 	/** @var string */
-	public static $customHeadStr = null;
+	public static $customCssStr = null;
+
+	/** @var string */
+	public static $customJsStr = null;
 
 	/** @var string */
 	public static $customBodyStr = null;


### PR DESCRIPTION
This provides an easy way to inject dynamically generated css or js (or any other content). This complements the recently added $customCssFiles and $customJsFiles options. The problem with those is that if you use PHP to generate JS/CSS based on conditions, there is no easy way to inject it to affect the debug bar itself (not just specific panels). This is especially difficult (impossible?) when there is a fatal error and the bluescreen is showing.

Thanks for considering. Maybe you have another idea for how to implement similar functionality?