### PR TITLE
Added support for __debugInfo() magic method.

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -7,8 +7,6 @@
 
 namespace Tracy;
 
-use Tracy;
-
 
 /**
  * Dumps a variable.
@@ -454,7 +452,21 @@ class Dumper
 				return call_user_func($dumper, $obj);
 			}
 		}
-		return (array) $obj;
+		if (version_compare(PHP_VERSION, '5.6.0') < 0) {
+			return (array) $obj;
+		}
+		if (!is_callable([$obj, '__debugInfo'])) {
+			return (array) $obj;
+		}
+		$fields = $obj->__debugInfo();
+		foreach ((array) $obj as $k => $v) {
+			$sk = substr($k, strrpos($k, "\x00") + 1);
+			if (isset($fields[$sk])) {
+				$fields[$k] = $v;
+				unset($fields[$sk]);
+			}
+		}
+		return $fields;
 	}
 
 

--- a/tests/Tracy/Dumper.toText().php56.phpt
+++ b/tests/Tracy/Dumper.toText().php56.phpt
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Test: Tracy\Dumper::toText()
+ * @phpVersion 5.6
+ */
+
+use Tester\Assert;
+use Tracy\Dumper;
+
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/fixtures/DumpClass.php';
+
+Assert::match('TestDebugInfo #%a%
+   a => 20
+   x => array (2)
+   |  0 => 10
+   |  1 => null
+   b => "virtual" (7)
+   d private => "visible" (7)
+   z protected => 30.0
+', Dumper::toText(new TestDebugInfo));

--- a/tests/Tracy/Dumper.toText().phpt
+++ b/tests/Tracy/Dumper.toText().phpt
@@ -65,7 +65,6 @@ Assert::match('Test #%a%
    z protected => 30.0
 ', Dumper::toText(new Test));
 
-
 $objStorage = new SplObjectStorage();
 $objStorage->attach($o1 = new stdClass);
 $objStorage[$o1] = 'o1';

--- a/tests/Tracy/fixtures/DumpClass.php
+++ b/tests/Tracy/fixtures/DumpClass.php
@@ -8,3 +8,19 @@ class Test
 
 	protected $z = 30.0;
 }
+
+class TestDebugInfo extends Test
+{
+	public $a = 20;
+
+	protected $c = "hidden";
+
+	private $d = "visible";
+
+	public function __debugInfo() {
+		$vars = get_object_vars($this);
+		unset($vars['c']);
+		$vars['b'] = 'virtual';
+		return $vars;
+	}
+}


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? yes

After this change result from \Tracy\Dumper::dump() will reflect the return value from __debugInfo() magic method (if defined).

As this might change output, I consider it as a BC break.
