### PR TITLE
Get nonce from both CSP and CSP-Report-Only headers

### DIFF
--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -242,7 +242,7 @@ class Helpers
 	/** @internal */
 	public static function getNonce()
 	{
-		return preg_match('#^Content-Security-Policy:.*\sscript-src\s+(?:[^;]+\s)?\'nonce-([\w+/]+=*)\'#mi', implode("\n", headers_list()), $m)
+		return preg_match('#^Content-Security-Policy(?:-Report-Only)?:.*\sscript-src\s+(?:[^;]+\s)?\'nonce-([\w+/]+=*)\'#mi', implode("\n", headers_list()), $m)
 			? $m[1]
 			: null;
 	}


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: will do

This one is also related to https://github.com/nette/http/pull/135. 