### PR TITLE
info.panel.html: fix undefined property in list of composer packages

### DIFF
--- a/src/Tracy/assets/Bar/info.panel.phtml
+++ b/src/Tracy/assets/Bar/info.panel.phtml
@@ -97,7 +97,7 @@ if (class_exists('Composer\Autoload\ClassLoader', false)) {
 	<?php if ($packages): ?>
 	<table>
 	<?php foreach ($packages as $package): ?>
-		<tr><td><?= Helpers::escapeHtml($package->name) ?></td><td><?= Helpers::escapeHtml($package->version . (strpos($package->version, 'dev') === false ? '' : ' #' . substr($package->source->reference, 0, 4))) ?></td></tr>
+		<tr><td><?= Helpers::escapeHtml($package->name) ?></td><td><?= Helpers::escapeHtml($package->version . (strpos($package->version, 'dev') === false ? '' : ' #' . substr(isset($package->source) ? $package->source->reference : $package->dist->reference, 0, 4))) ?></td></tr>
 	<?php endforeach ?>
 	</table>
 	<?php endif ?>
@@ -106,7 +106,7 @@ if (class_exists('Composer\Autoload\ClassLoader', false)) {
 	<h2>Dev Packages</h2>
 	<table>
 	<?php foreach ($devPackages as $package): ?>
-		<tr><td><?= Helpers::escapeHtml($package->name) ?></td><td><?= Helpers::escapeHtml($package->version . (strpos($package->version, 'dev') === false ? '' : ' #' . substr($package->source->reference, 0, 4))) ?></td></tr>
+		<tr><td><?= Helpers::escapeHtml($package->name) ?></td><td><?= Helpers::escapeHtml($package->version . (strpos($package->version, 'dev') === false ? '' : ' #' . substr(isset($package->source) ? $package->source->reference : $package->dist->reference, 0, 4))) ?></td></tr>
 	<?php endforeach ?>
 	</table>
 	<?php endif ?>


### PR DESCRIPTION
- bug fix? yes
- BC break? no

Field `source` is not mandatory. For example, my local repositories
mirrored from a path do not have the field in `composer.lock`. Refs
to `source` and `dist` are the same on all my dependencies and even
in file `Locker.php` of `composer/composer` package there is the
retrieval of reference ID fall-backed by using `dist` field.

https://github.com/composer/composer/blob/28e41d094e78e0a60dc5123ee572701154008848/src/Composer/Package/Locker.php#L417
