### PR TITLE
Fix shifting of bar to top right when reloading page after closing/hiding

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -320,6 +320,7 @@
 
 
 		savePosition() {
+			if(document.getElementById('tracy-debug').style.display == 'none') return;
 			var pos = getPosition(this.elem);
 			localStorage.setItem(this.id, JSON.stringify(this.isAtTop() ? {right: pos.right, top: pos.top} : {right: pos.right, bottom: pos.bottom}));
 		}


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Not sure if this is the most elegant solution, but currently in 2.5-dev if you click the 'close debug bar' icon and reload the page, the bar ends up at the top left of the viewport. This is because when `display: none`, the `isAtTop()` method always returns true. My fix prevents updating the saved position (via `savePosition()`) when the bar is hidden (`display:none`).
