### PR TITLE
Linux "open-editor" supports "create" and "fix" actions.

### DIFF
--- a/tools/open-in-editor/linux/open-editor.sh
+++ b/tools/open-in-editor/linux/open-editor.sh
@@ -1,39 +1,101 @@
 #!/bin/bash
+declare -A mapping
 
+#
+# Configure your editor by setting the $editor variable:
+#
+
+# Visual Studio Code
+#editor='code --goto "$FILE":"$LINE"'
 # Emacs
 #editor='emacs +$LINE "$FILE"'
-
 # gVim
 #editor='gvim +$LINE "$FILE"'
-
 # gEdit
 #editor='gedit +$LINE "$FILE"'
-
 # Pluma
 #editor='pluma +$LINE "$FILE"'
 
+#
+# Optionally configure custom mapping here:
+#
 
+#mapping["/remotepath"]="/localpath"
+#mapping["/mnt/d/"]="d:/"
 
-declare -A mappings
-#mappings["/remotepath"]="/localpath"
+#
+# Please, do not modify the code below.
+#
 
+# Find and return URI parameter value. Or nothing, if the param is missing.
+# Arguments: 1) URI, 2) Parameter name.
+function get_param {
+	echo "$1" | sed -n -r "s/.*$2=([^&]+).*/\1/ip"
+}
+
+if [[ -z "$editor" ]]; then
+	echo "You need to set the \$editor variable in file '`realpath $0`'"
+	exit
+fi
 
 url=$1
-if [ "${url:0:20}" == "editor://open/?file=" ]; then
-
-	regex='editor\:\/\/(open|create|fix)\/\?file\=(.+)\&line\=([0-9]+)\&search=(.+)\&replace=(.+)'
-	action=`echo $url | sed -r "s/$regex/\1/i"`
-	file=`echo $url | sed -r "s/$regex/\2/i"`
-	line=`echo $url | sed -r "s/$regex/\3/i"`
-	printf -v file "${file//%/\\x}" # decode url
-	file=${file//\"/\\\"} # escape quotes
-
-	command="${editor//\$FILE/$file}"
-	command="${command//\$LINE/$line}"
-
-	for path in "${!mappings[@]}"; do
-		command="${command//$path/${mappings[$path]}}"
-	done
-
-	eval $command
+if [ "${url:0:9}" != "editor://" ]; then
+	exit
 fi
+
+# Parse action and essential data from the URI.
+regex='editor\:\/\/(open|create|fix)\/\?(.*)'
+action=`echo $url | sed -r "s/$regex/\1/i"`
+uri_params=`echo $url | sed -r "s/$regex/\2/i"`
+
+file=`get_param $uri_params "file"`
+line=`get_param $uri_params "line"`
+search=`get_param $uri_params "search"`
+replace=`get_param $uri_params "replace"`
+
+# Debug?
+#echo "action '$action'"
+#echo "file '$file'"
+#echo "line '$line'"
+#echo "search '$search'"
+#echo "replace '$replace'"
+
+# Convert URI encoded codes to normal characters (e.g. '%2F' => '/').
+printf -v file "${file//%/\\x}"
+# And escape double-quotes.
+file=${file//\"/\\\"}
+
+# Action: Create a file (only if it does not already exist).
+if [ "$action" == "create" ] && [[ ! -f "$file" ]]; then
+	mkdir -p $(dirname "$file")
+	touch "$file"
+fi
+
+# Action: Fix the file (if the file exists and while creating backup beforehand).
+if [ "$action" == "fix" ]; then
+
+	if [[ ! -f "$file" ]]; then
+		echo "Cannot fix non-existing file '$file'"
+		exit
+	fi
+
+	# Backup the original file.
+	cp $file "$file.bak"
+	# Search and replace in place - only on the specified line.
+	sed -i "${line}s/${search}/${replace}/" $file
+
+fi
+
+# Apply custom mapping conversion.
+for path in "${!mapping[@]}"; do
+	file="${file//$path/${mapping[$path]}}"
+done
+
+# Format the command according to the selected editor.
+command="${editor//\$FILE/$file}"
+command="${command//\$LINE/$line}"
+
+# Debug?
+#echo $command
+
+eval $command


### PR DESCRIPTION
- New feature.
- No BC break intended.
- Based on: https://twitter.com/geekovo/status/997538920278773761

Updated Linux "open-editor" bash script to support the new *"create"* and *"fix"* actions that can now be used via the `editor://` protocol.

- Traditional **`open` action**:
  - Should behave the same as always.
- New **`create` action**:
  - Will create file at the location specified in the `file` parameter, **if it does not already exist**. Then opens the file.
  - Any necessary but non-existing directories are created (recursively).
- New **`fix` action**:
  - Performs search (`search` param) and replace (`replace` param) in the file (`file` param) at the specified line (`line` param, if specified). Then opens the file.
  - Fails if the file does not exist.
- The order of GET parameters in the `editor:// ...` URI is now *not* important - **parameters can be set in any order**.
- Added `$editor` command template for Visual Studio Code.
- Exit with message if the `$editor` variable is not specified.