### PR TITLE
open-editor.js: backward compatible regexp

### DIFF
--- a/tools/open-in-editor/windows/open-editor.js
+++ b/tools/open-in-editor/windows/open-editor.js
@@ -38,7 +38,7 @@ if (!settings.editor) {
 }
 
 var url = WScript.Arguments(0);
-var match = /^editor:\/\/(open|create|fix)\/\?file=([^&]+)&line=(\d+)&search=([^&]*)&replace=([^&]*)/.exec(url);
+var match = /^editor:\/\/(open|create|fix)\/\?file=([^&]+)&line=(\d+)(?:&search=([^&]*)&replace=([^&]*))?/.exec(url);
 if (!match) {
 	WScript.Echo('Unexpected URI ' + url);
 	WScript.Quit();


### PR DESCRIPTION
- bug fix
- BC break? no

To be compatible with older Tracy.