### PR TITLE
PSR-3 adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 	},
 	"require-dev": {
 		"nette/di": "^2.4 || ^3.0",
-		"nette/tester": "^2.0"
+		"nette/tester": "^2.0",
+		"psr/log": "^1.0"
 	},
 	"suggest": {
 		"https://nette.org/donate": "Please support Tracy via a donation"

--- a/src/Bridges/Psr/PsrToTracyLoggerAdapter.php
+++ b/src/Bridges/Psr/PsrToTracyLoggerAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the Tracy (https://tracy.nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Tracy\Bridges\Psr;
+
+use Psr;
+use Tracy;
+
+
+/**
+ * Psr\Log\LoggerInterface to Tracy\ILogger adapter.
+ */
+class PsrToTracyLoggerAdapter implements Tracy\ILogger
+{
+	/** Tracy logger priority to PSR-3 log level mapping */
+	private const PRIORITY_MAP = [
+		Tracy\ILogger::DEBUG => Psr\Log\LogLevel::DEBUG,
+		Tracy\ILogger::INFO => Psr\Log\LogLevel::INFO,
+		Tracy\ILogger::WARNING => Psr\Log\LogLevel::WARNING,
+		Tracy\ILogger::ERROR => Psr\Log\LogLevel::ERROR,
+		Tracy\ILogger::EXCEPTION => Psr\Log\LogLevel::ERROR,
+		Tracy\ILogger::CRITICAL => Psr\Log\LogLevel::CRITICAL,
+	];
+
+	/** @var Psr\Log\LoggerInterface */
+	private $psrLogger;
+
+
+	public function __construct(Psr\Log\LoggerInterface $psrLogger)
+	{
+		$this->psrLogger = $psrLogger;
+	}
+
+
+	public function log($value, string $priority = self::INFO)
+	{
+		if ($value instanceof \Throwable) {
+			$message = $value->getMessage();
+			$context = ['exception' => $value];
+
+		} elseif (!is_string($value)) {
+			$message = trim(Tracy\Dumper::toText($value));
+			$context = [];
+
+		} else {
+			$message = $value;
+			$context = [];
+		}
+
+		$this->psrLogger->log(
+			self::PRIORITY_MAP[$priority] ?? Psr\Log\LogLevel::ERROR,
+			$message,
+			$context
+		);
+	}
+}

--- a/src/Bridges/Psr/TracyToPsrLoggerAdapter.php
+++ b/src/Bridges/Psr/TracyToPsrLoggerAdapter.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the Tracy (https://tracy.nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Tracy\Bridges\Psr;
+
+use Psr;
+use Tracy;
+
+
+/**
+ * Tracy\ILogger to Psr\Log\LoggerInterface adapter.
+ */
+class TracyToPsrLoggerAdapter extends Psr\Log\AbstractLogger
+{
+	/** PSR-3 log level to Tracy logger priority mapping */
+	private const PRIORITY_MAP = [
+		Psr\Log\LogLevel::EMERGENCY => Tracy\ILogger::CRITICAL,
+		Psr\Log\LogLevel::ALERT => Tracy\ILogger::CRITICAL,
+		Psr\Log\LogLevel::CRITICAL => Tracy\ILogger::CRITICAL,
+		Psr\Log\LogLevel::ERROR => Tracy\ILogger::ERROR,
+		Psr\Log\LogLevel::WARNING => Tracy\ILogger::WARNING,
+		Psr\Log\LogLevel::NOTICE => Tracy\ILogger::WARNING,
+		Psr\Log\LogLevel::INFO => Tracy\ILogger::INFO,
+		Psr\Log\LogLevel::DEBUG => Tracy\ILogger::DEBUG,
+	];
+
+	/** @var Tracy\ILogger */
+	private $tracyLogger;
+
+
+	public function __construct(Tracy\ILogger $tracyLogger)
+	{
+		$this->tracyLogger = $tracyLogger;
+	}
+
+
+	public function log($level, $message, array $context = [])
+	{
+		$priority = self::PRIORITY_MAP[$level] ?? Tracy\ILogger::ERROR;
+
+		if (isset($context['exception']) && $context['exception'] instanceof \Throwable) {
+			$this->tracyLogger->log($context['exception'], $priority);
+			unset($context['exception']);
+		}
+
+		if ($context) {
+			$message = [
+				'message' => $message,
+				'context' => $context,
+			];
+		}
+
+		$this->tracyLogger->log($message, $priority);
+	}
+}

--- a/tests/Tracy.Bridges/PsrToTracyLoggerAdapter.phpt
+++ b/tests/Tracy.Bridges/PsrToTracyLoggerAdapter.phpt
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Test: PsrToTracyLoggerAdapter.
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+use Tracy\Bridges\Psr\PsrToTracyLoggerAdapter;
+use Tracy\ILogger;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+class DummyPsrLogger extends Psr\Log\AbstractLogger
+{
+	/** @var array */
+	public $entries = [];
+
+
+	public function log($level, $message, array $context = [])
+	{
+		$this->entries[] = [$level, $message, $context];
+	}
+}
+
+
+$psrLogger = new DummyPsrLogger;
+$tracyLogger = new PsrToTracyLoggerAdapter($psrLogger);
+$exception = new \Exception('Something went wrong');
+
+$tracyLogger->log('info');
+$tracyLogger->log('warning', ILogger::WARNING);
+$tracyLogger->log(123);
+$tracyLogger->log(['x' => 'y']);
+$tracyLogger->log($exception);
+
+Assert::same([
+	[Psr\Log\LogLevel::INFO, 'info', []],
+	[Psr\Log\LogLevel::WARNING, 'warning', []],
+	[Psr\Log\LogLevel::INFO, '123', []],
+	[Psr\Log\LogLevel::INFO, "array (1)\n   x => \"y\"", []],
+	[Psr\Log\LogLevel::INFO, 'Something went wrong', ['exception' => $exception]],
+], $psrLogger->entries);

--- a/tests/Tracy.Bridges/TracyToPsrLoggerAdapter.phpt
+++ b/tests/Tracy.Bridges/TracyToPsrLoggerAdapter.phpt
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Test: TracyToPsrLoggerAdapter.
+ */
+
+declare(strict_types=1);
+
+use Tester\Assert;
+use Tracy\Bridges\Psr\TracyToPsrLoggerAdapter;
+use Tracy\ILogger;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+class DummyTracyLogger implements ILogger
+{
+	/** @var array */
+	public $entries = [];
+
+
+	public function log($value, string $priority = self::INFO)
+	{
+		$this->entries[] = [$priority, $value];
+	}
+}
+
+
+$tracyLogger = new DummyTracyLogger;
+$psrLogger = new TracyToPsrLoggerAdapter($tracyLogger);
+$exception = new \Exception('Something went wrong');
+
+$psrLogger->info('info');
+$psrLogger->warning('warning');
+$psrLogger->error('order failed with exception', ['exception' => $exception]);
+$psrLogger->error('order failed with context', ['orderId' => 123]);
+$psrLogger->error('order failed with context and exception', ['orderId' => 123, 'exception' => $exception]);
+
+Assert::same([
+	[ILogger::INFO, 'info'],
+	[ILogger::WARNING, 'warning'],
+	[ILogger::ERROR, $exception],
+	[ILogger::ERROR, 'order failed with exception'],
+	[ILogger::ERROR, ['message' => 'order failed with context', 'context' => ['orderId' => 123]]],
+	[ILogger::ERROR, $exception],
+	[ILogger::ERROR, ['message' => 'order failed with context and exception', 'context' => ['orderId' => 123]]],
+], $tracyLogger->entries);


### PR DESCRIPTION
@dg Would you accept PR with PSR-3 adapter? So it would be possible to use any PSR-3 compatible logger (e.g. Monolog) with Tracy, i.e. the following would be possible

~~~php
$psrLogger = new Monolog\Logger(...);
$tracyLogger = new Tracy\Bridges\Psr\PsrLoggerAdapter($psrLogger);
Tracy\Debugger::setLogger($tracyLogger);
~~~

Or we could even apply the adapter automatically, so the following would be possible:


~~~php
$psrLogger = new Monolog\Logger(...);
Tracy\Debugger::setLogger($psrLogger);
~~~