### PR TITLE
bar.js: send with Content-type: application/javascript

### DIFF
--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -174,7 +174,7 @@ class Bar
 	{
 		$asset = $_GET['_tracy_bar'] ?? null;
 		if ($asset === 'js') {
-			header('Content-Type: text/javascript');
+			header('Content-Type: application/javascript');
 			header('Cache-Control: max-age=864000');
 			header_remove('Pragma');
 			header_remove('Set-Cookie');
@@ -190,7 +190,7 @@ class Bar
 
 		if ($this->useSession && $asset && preg_match('#^content(-ajax)?\.(\w+)$#', $asset, $m)) {
 			$session = &$_SESSION['_tracy']['bar'][$m[2] . $m[1]];
-			header('Content-Type: text/javascript');
+			header('Content-Type: application/javascript');
 			header('Cache-Control: max-age=60');
 			header_remove('Set-Cookie');
 			if (!$m[1]) {


### PR DESCRIPTION
- Type: bug fix
- BC break: yes, but probably no effective
- No tests or docs affected or applied

Tracy is sending Tracy\Bar components with `Content-Type: text/javascript`.

According to [RFC 4329](https://www.rfc-editor.org/rfc/rfc4329.txt) (chapter 7.1) is `text/javascript` **obsolete** and should be used `application/javascript` instead.

In real case it make light impediment to right detect, and process response. For example [`.htaccess` in nette/web-project](https://github.com/nette/web-project/blob/7132061169a4f1f66c443a58e06ccc26b6964807/www/.htaccess#L26) is set `DEFLATE` filter only for `application/javascript` mime. I mean it's just mistake, not intentionally.
