### PR TITLE
BlueScreen: renderToFile() returns bool to indicate if file was written by current process

### DIFF
--- a/src/Tracy/BlueScreen.php
+++ b/src/Tracy/BlueScreen.php
@@ -86,7 +86,7 @@ class BlueScreen
 	/**
 	 * Renders blue screen to file (if file exists, it will not be overwritten).
 	 */
-	public function renderToFile(\Throwable $exception, string $file): void
+	public function renderToFile(\Throwable $exception, string $file): bool
 	{
 		if ($handle = @fopen($file, 'x')) {
 			ob_start(); // double buffer prevents sending HTTP headers in some PHP
@@ -95,7 +95,9 @@ class BlueScreen
 			ob_end_flush();
 			ob_end_clean();
 			fclose($handle);
+			return true;
 		}
+		return false;
 	}
 
 


### PR DESCRIPTION
- bug fix / new feature? minor low-level feature
- BC break? no
- doc PR: too low-level to be worth documenting

I need to upload the bluescreen to remote storage (AWS S3 in my case). This is what I'm doing currently

```php
$lockPath = "$localPath.lock";
$lockHandle = @fopen($lockPath, 'x');
if ($lockHandle === false) {
	return;
}

Tracy\Debugger::getBlueScreen()->renderToFile($exception, $localPath);
$this->remoteStorageDriver->upload($localPath);

@fclose($lockHandle);
@unlink($lockPath);
```

The proposed change would allow to simplify to code to

```php
if (Tracy\Debugger::getBlueScreen()->renderToFile($exception, $localPath)) {
	$this->remoteStorageDriver->upload($localPath);
}
```