### PR TITLE
Recount hiding of labels when resized

### DIFF
--- a/src/Tracy/assets/Bar/bar.js
+++ b/src/Tracy/assets/Bar/bar.js
@@ -242,6 +242,8 @@
 
 			this.initTabs(this.elem);
 			this.restorePosition();
+			
+			window.addEventListener('resize', () => this.autoHideLabels);
 
 			(new MutationObserver(() => {
 				this.restorePosition();


### PR DESCRIPTION
- new feature
- BC break? no

Calls `Bar.autoHideLabels()` method on every resize of viewport. This is useful when testing web responsivness - you resize the viewport all the time but Tracy does not react with showing/hiding labels when there is (not) enough of space.

Even better would be media query driven showing/hiding.