### PR TITLE
Dumper: do not quote dumped keys

### DIFF
--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -229,9 +229,8 @@ class Dumper
 			foreach ($var as $k => &$v) {
 				if ($k !== $marker) {
 					$hide = is_string($k) && isset($options[self::KEYS_TO_HIDE][strtolower($k)]) ? self::HIDDEN_VALUE : null;
-					$k = is_int($k) || preg_match('#^\w{1,50}\z#', $k) ? $k : '"' . Helpers::escapeHtml(self::encodeString($k, $options[self::TRUNCATE])) . '"';
 					$inner .= '<span class="tracy-dump-indent">   ' . str_repeat('|  ', $level) . '</span>'
-						. '<span class="tracy-dump-key">' . $k . '</span> => '
+						. '<span class="tracy-dump-key">' . Helpers::escapeHtml(self::key($k, $options)) . '</span> => '
 						. ($hide ? self::dumpString($hide, $options) : self::dumpVar($v, $options, $level + 1));
 				}
 			}
@@ -294,9 +293,8 @@ class Dumper
 					$k = substr($k, strrpos($k, "\x00") + 1);
 				}
 				$hide = is_string($k) && isset($options[self::KEYS_TO_HIDE][strtolower($k)]) ? self::HIDDEN_VALUE : null;
-				$k = is_int($k) || preg_match('#^\w{1,50}\z#', $k) ? $k : '"' . Helpers::escapeHtml(self::encodeString($k, $options[self::TRUNCATE])) . '"';
 				$inner .= '<span class="tracy-dump-indent">   ' . str_repeat('|  ', $level) . '</span>'
-					. '<span class="tracy-dump-key">' . $k . "</span>$vis => "
+					. '<span class="tracy-dump-key">' . Helpers::escapeHtml(self::key($k, $options)) . "</span>$vis => "
 					. ($hide ? self::dumpString($hide, $options) : self::dumpVar($v, $options, $level + 1));
 			}
 			array_pop($list);
@@ -330,6 +328,19 @@ class Dumper
 	}
 
 
+	private static function key($k, array $options)
+	{
+		if (is_int($k) || preg_match('#^\w{1,50}\z#', $k)) {
+			return $k;
+
+		} elseif ($k === '') {
+			return '""';
+		}
+
+		return self::encodeString($k, $options[self::TRUNCATE]);
+	}
+
+
 	/**
 	 * @return mixed
 	 */
@@ -359,8 +370,7 @@ class Dumper
 			foreach ($var as $k => &$v) {
 				if ($k !== $marker) {
 					$hide = is_string($k) && isset($options[self::KEYS_TO_HIDE][strtolower($k)]);
-					$k = is_int($k) || preg_match('#^\w{1,50}\z#', $k) ? $k : '"' . self::encodeString($k, $options[self::TRUNCATE]) . '"';
-					$res[] = [$k, $hide ? self::HIDDEN_VALUE : self::toJson($v, $options, $level + 1)];
+					$res[] = [self::key($k, $options), $hide ? self::HIDDEN_VALUE : self::toJson($v, $options, $level + 1)];
 				}
 			}
 			unset($var[$marker]);
@@ -398,8 +408,7 @@ class Dumper
 						$k = substr($k, strrpos($k, "\x00") + 1);
 					}
 					$hide = is_string($k) && isset($options[self::KEYS_TO_HIDE][strtolower($k)]);
-					$k = is_int($k) || preg_match('#^\w{1,50}\z#', $k) ? $k : '"' . self::encodeString($k, $options[self::TRUNCATE]) . '"';
-					$obj['items'][] = [$k, $hide ? self::HIDDEN_VALUE : self::toJson($v, $options, $level + 1), $vis];
+					$obj['items'][] = [self::key($k, $options), $hide ? self::HIDDEN_VALUE : self::toJson($v, $options, $level + 1), $vis];
 				}
 			}
 			return ['object' => $obj['id']];

--- a/src/Tracy/Dumper.php
+++ b/src/Tracy/Dumper.php
@@ -333,8 +333,8 @@ class Dumper
 		if (is_int($k) || preg_match('#^\w{1,50}\z#', $k)) {
 			return $k;
 
-		} elseif ($k === '') {
-			return '""';
+		} elseif ($k === '' || preg_match('#(?:^\W|\W\z)#', $k)) {
+			return '"' . $k . '"';
 		}
 
 		return self::encodeString($k, $options[self::TRUNCATE]);

--- a/tests/Tracy/Dumper.keys.phpt
+++ b/tests/Tracy/Dumper.keys.phpt
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+use Tracy\Dumper;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$keys = [
+	'' => 0,
+	'"' => 0,
+	"'" => 0,
+	' key' => 0,
+	'key ' => 0,
+	0 => 0,
+	'01' => 0,
+];
+
+Assert::match('array (%i%)
+   "" => 0
+   """ => 0
+   "\'" => 0
+   " key" => 0
+   "key " => 0
+   0 => 0
+   01 => 0
+', Dumper::toText($keys));
+
+Assert::match('stdClass #%a%
+   "" => 0
+   """ => 0
+   "\'" => 0
+   " key" => 0
+   "key " => 0
+   0 => 0
+   01 => 0
+', Dumper::toText((object) $keys));
+
+Assert::match(
+	'<pre class="tracy-dump" data-tracy-dump=\'{"object":"01"}\'></pre>',
+	Dumper::toHtml((object) $keys, [Dumper::LIVE => true])
+);
+
+Assert::same([
+	'01' => [
+		'name' => 'stdClass',
+		'editor' => null,
+		'items' => [
+			['""', 0, 0],
+			['"""', 0, 0],
+			['"\'"', 0, 0],
+			['" key"', 0, 0],
+			['"key "', 0, 0],
+			[0, 0, 0],
+			['01', 0, 0],
+		],
+	],
+], Dumper::fetchLiveData());

--- a/tests/Tracy/Dumper.objectExporters.phpt
+++ b/tests/Tracy/Dumper.objectExporters.phpt
@@ -39,9 +39,9 @@ $obj = unserialize('O:1:"Y":7:{s:1:"a";N;s:1:"b";i:2;s:4:"' . "\0" . '*' . "\0" 
 Assert::match('__PHP_Incomplete_Class #%a%
    className => "Y"
    private => array (3)
-   |  "Y::$e" => null
-   |  "Y::$i" => "bar" (3)
-   |  "X::$i" => "foo" (3)
+   |  Y::$e => null
+   |  Y::$i => "bar" (3)
+   |  X::$i => "foo" (3)
    protected => array (2)
    |  c => null
    |  d => "d"


### PR DESCRIPTION
Is there any reason for quoting dumped array keys/object property names? For example:
```
array (2)
    Accept => "application/json" (16)
    "User-Agent" => "milo/http-client-v5.2" (21)
```

Empty string is preserver quoted.