### PR TITLE
Fix "syntax error, unexpected end of file" error

### DIFF
--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -345,7 +345,7 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			<p><i>no headers</i></p>
 			<?php endif ?>
 		</div></div>
-		<? endif ?>
+		<?php endif ?>
 
 
 		<?php foreach ($bottomPanels as $panel): ?>


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: -

Cherry pick of commit 2fbe913f09ad6735d3182af760b75111f2b1b5dd from `master` to `v2.6` branch.

That fixes syntax error of Blueprint template on `short_open_tag=Off` PHP configuration.