### PR TITLE
Nette bridge – fix Container compilation, remove redundant argument

### DIFF
--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -117,7 +117,7 @@ class TracyExtension extends Nette\DI\CompilerExtension
 			}
 
 			if (!$this->cliMode && ($name = $builder->getByType(Nette\Http\Session::class))) {
-				$initialize->addBody('$this->getService(?)->start();', [$name, $name]);
+				$initialize->addBody('$this->getService(?)->start();', [$name]);
 				$initialize->addBody('Tracy\Debugger::dispatch();');
 			}
 		}

--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -98,8 +98,7 @@ class TracyExtension extends Nette\DI\CompilerExtension
 			$initialize->addBody($builder->formatPhp('Tracy\Debugger::setLogger(?);', [$logger]));
 		}
 		if ($this->config['netteMailer'] && $builder->getByType(Nette\Mail\IMailer::class)) {
-			$initialize->addBody($builder->formatPhp('Tracy\Debugger::getLogger(?)->mailer = ?;', [
-				$logger,
+			$initialize->addBody($builder->formatPhp('Tracy\Debugger::getLogger()->mailer = ?;', [
 				[new Nette\DI\Statement(Tracy\Bridges\Nette\MailSender::class, ['fromEmail' => $this->config['fromEmail']]), 'send'],
 			]));
 		}
@@ -117,8 +116,9 @@ class TracyExtension extends Nette\DI\CompilerExtension
 				));
 			}
 
-			if (!$this->cliMode) {
-				$initialize->addBody('if ($tmp = $this->getByType("Nette\Http\Session", false)) { $tmp->start(); Tracy\Debugger::dispatch(); };');
+			if (!$this->cliMode && ($name = $builder->getByType(Nette\Http\Session::class))) {
+				$initialize->addBody('$this->getService(?)->start();', [$name, $name]);
+				$initialize->addBody('Tracy\Debugger::dispatch();');
 			}
 		}
 

--- a/src/Tracy/Bar/Bar.php
+++ b/src/Tracy/Bar/Bar.php
@@ -215,6 +215,7 @@ class Bar
 		$css = array_map('file_get_contents', array_merge([
 			__DIR__ . '/assets/bar.css',
 			__DIR__ . '/../Toggle/toggle.css',
+			__DIR__ . '/../TableSort/table-sort.css',
 			__DIR__ . '/../Dumper/assets/dumper.css',
 			__DIR__ . '/../BlueScreen/assets/bluescreen.css',
 		], Debugger::$customCssFiles));

--- a/src/Tracy/Bar/assets/bar.js
+++ b/src/Tracy/Bar/assets/bar.js
@@ -6,6 +6,7 @@
 
 (function(){
 	let nonce, contentId, ajaxCounter = 1;
+	let baseUrl = location.href.split('#')[0] + (location.href.indexOf('?') < 0 ? '?' : '&');
 
 	class Panel
 	{
@@ -139,7 +140,7 @@
 
 			let doc = win.document;
 			doc.write('<!DOCTYPE html><meta charset="utf-8">'
-			+ '<script src="?_tracy_bar=js&amp;XDEBUG_SESSION_STOP=1" onload="Tracy.Dumper.init()" async></script>'
+			+ '<script src="' + (baseUrl.replace('&', '&amp;').replace('<', '&lt;').replace('"', '&quot;')) + '_tracy_bar=js&amp;XDEBUG_SESSION_STOP=1" onload="Tracy.Dumper.init()" async></script>'
 			+ '<body id="tracy-debug">'
 			);
 			doc.body.innerHTML = '<div class="tracy-panel tracy-mode-window" id="' + this.elem.id + '">' + this.elem.innerHTML + '</div>';
@@ -471,7 +472,7 @@
 					this.setRequestHeader('X-Tracy-Ajax', reqId);
 					this.addEventListener('load', function() {
 						if (this.getAllResponseHeaders().match(/^X-Tracy-Ajax: 1/mi)) {
-							Debug.loadScript('?_tracy_bar=content-ajax.' + reqId + '&XDEBUG_SESSION_STOP=1&v=' + Math.random());
+							Debug.loadScript(baseUrl + '_tracy_bar=content-ajax.' + reqId + '&XDEBUG_SESSION_STOP=1&v=' + Math.random());
 						}
 					});
 				}
@@ -486,7 +487,7 @@
 					request.headers.set('X-Tracy-Ajax', reqId);
 					return oldFetch(request).then((response) => {
 						if (response.headers.has('X-Tracy-Ajax') && response.headers.get('X-Tracy-Ajax')[0] === '1') {
-							Debug.loadScript('?_tracy_bar=content-ajax.' + reqId + '&XDEBUG_SESSION_STOP=1&v=' + Math.random());
+							Debug.loadScript(baseUrl + '_tracy_bar=content-ajax.' + reqId + '&XDEBUG_SESSION_STOP=1&v=' + Math.random());
 						}
 
 						return response;

--- a/src/Tracy/Bar/assets/loader.phtml
+++ b/src/Tracy/Bar/assets/loader.phtml
@@ -13,19 +13,20 @@ declare(strict_types=1);
 
 namespace Tracy;
 
-$baseUrl = explode('?', $_SERVER['REQUEST_URI'] ?? '')[0];
+$baseUrl = $_SERVER['REQUEST_URI'] ?? '';
+$baseUrl .= strpos($baseUrl, '?') === false ? '?' : '&';
 $nonceAttr = $nonce ? ' nonce="' . Helpers::escapeHtml($nonce) . '"' : '';
 $asyncAttr = $async ? ' async' : '';
 ?>
 <?php if (empty($content)): ?>
-<script src="<?= Helpers::escapeHtml($baseUrl) ?>?_tracy_bar=<?= urlencode("content.$contentId") ?>&amp;XDEBUG_SESSION_STOP=1" data-id="<?= Helpers::escapeHtml($contentId) ?>"<?= $asyncAttr, $nonceAttr ?>></script>
+<script src="<?= Helpers::escapeHtml($baseUrl) ?>_tracy_bar=<?= urlencode("content.$contentId") ?>&amp;XDEBUG_SESSION_STOP=1" data-id="<?= Helpers::escapeHtml($contentId) ?>"<?= $asyncAttr, $nonceAttr ?>></script>
 <?php else: ?>
 
 
 
 
 <!-- Tracy Debug Bar -->
-<script src="<?= Helpers::escapeHtml($baseUrl) ?>?_tracy_bar=js&amp;v=<?= urlencode(Debugger::VERSION) ?>&amp;XDEBUG_SESSION_STOP=1" data-id="<?= Helpers::escapeHtml($contentId) ?>"<?= $nonceAttr ?>></script>
+<script src="<?= Helpers::escapeHtml($baseUrl) ?>_tracy_bar=js&amp;v=<?= urlencode(Debugger::VERSION) ?>&amp;XDEBUG_SESSION_STOP=1" data-id="<?= Helpers::escapeHtml($contentId) ?>"<?= $nonceAttr ?>></script>
 <script<?= $nonceAttr ?>>
 Tracy.Debug.init(<?= str_replace('</s', '<\/s', json_encode($content, JSON_UNESCAPED_SLASHES)) ?>);
 </script>

--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -135,6 +135,9 @@ class BlueScreen
 
 		$css = array_map('file_get_contents', array_merge([
 			__DIR__ . '/assets/bluescreen.css',
+			__DIR__ . '/../Toggle/toggle.css',
+			__DIR__ . '/../TableSort/table-sort.css',
+			__DIR__ . '/../Dumper/assets/dumper.css',
 		], Debugger::$customCssFiles));
 		$css = preg_replace('#\s+#u', ' ', implode($css));
 

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -14,30 +14,6 @@
 	text-align: left;
 }
 
-#tracy-bs * {
-	font: inherit;
-	color: inherit;
-	background: transparent;
-	border: none;
-	margin: 0;
-	padding: 0;
-	text-align: inherit;
-	text-indent: 0;
-}
-
-#tracy-bs *:before,
-#tracy-bs *:after {
-	all: unset;
-}
-
-#tracy-bs b {
-	font-weight: bold;
-}
-
-#tracy-bs i {
-	font-style: italic;
-}
-
 #tracy-bs a {
 	text-decoration: none;
 	color: #328ADC;
@@ -86,13 +62,6 @@
 	font-style: normal;
 }
 
-#tracy-bs-ie-warning {
-	background: black;
-	margin: 1em;
-	padding: .5em;
-	text-align: center;
-}
-
 #tracy-bs h1 {
 	font-size: 15pt;
 	font-weight: normal;
@@ -106,6 +75,7 @@
 
 #tracy-bs h2 {
 	font-size: 14pt;
+	font-weight: normal;
 	margin: .6em 0;
 }
 
@@ -166,19 +136,6 @@
 #tracy-bs tr:nth-child(2n),
 #tracy-bs tr:nth-child(2n) pre {
 	background-color: #F7F0CB;
-}
-
-/* TableSort */
-#tracy-bs .tracy-sortable tr:first-child > * {
-	position: relative;
-}
-
-#tracy-bs .tracy-sortable tr:first-child > *:hover:before {
-	position: absolute;
-	right: .3em;
-	content: "\21C5";
-	opacity: .4;
-	font-weight: normal;
 }
 
 #tracy-bs ol {
@@ -266,87 +223,9 @@
 	border-bottom: 1px dotted rgba(0, 0, 0, .3);
 }
 
-
-/* toggle */
-html.tracy-js #tracy-bs .tracy-collapsed {
-	display: none;
-}
-
-html.tracy-js #tracy-bs .tracy-toggle.tracy-collapsed {
-	display: inline;
-}
-
-#tracy-bs .tracy-toggle {
-	cursor: pointer;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-khtml-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
-
-#tracy-bs .tracy-toggle:after {
-	content: "\A0\25BC";
-	opacity: .4;
-}
-
-#tracy-bs .tracy-toggle.tracy-collapsed:after {
-	content: "\A0\25BA";
-}
-
-
-/* dump */
-#tracy-bs .tracy-dump-array,
-#tracy-bs .tracy-dump-object {
-	color: #C22;
-}
-
-#tracy-bs .tracy-dump-string {
-	color: #35D;
-}
-
-#tracy-bs .tracy-dump-number {
-	color: #090;
-}
-
 #tracy-bs .tracy-dump-whitespace {
 	color: #0003;
 }
-
-#tracy-bs .tracy-dump-null,
-#tracy-bs .tracy-dump-bool {
-	color: #850;
-}
-
-#tracy-bs .tracy-dump-visibility,
-#tracy-bs .tracy-dump-hash {
-	font-size: 85%;
-	color: #998;
-}
-
-#tracy-bs .tracy-dump-indent {
-	display: none;
-}
-
-#tracy-bs pre.tracy-dump div {
-	padding-left: 3ex;
-}
-
-#tracy-bs pre.tracy-dump div div {
-	border-left: 1px solid rgba(0, 0, 0, .1);
-	margin-left: .5ex;
-}
-
-#tracy-bs .tracy-dump-flash {
-	animation: tracy-dump-flash .2s ease;
-}
-
-@keyframes tracy-dump-flash {
-	0% {
-		background: #c0c0c033;
-	}
-}
-
 
 #tracy-bs .caused {
 	float: right;

--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -274,6 +274,26 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 		</div></div>
 
 
+		<?php if (PHP_SAPI === 'cli'): ?>
+		<div class="panel">
+		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">CLI request</a></h2>
+
+		<div class="tracy-collapsed inner">
+			<h3>Process ID <?= Helpers::escapeHtml(getmypid()) ?></h3>
+			<pre>php<?= Helpers::escapeHtml(explode('):', $source, 2)[1]) ?></pre>
+
+			<h3>Arguments</h3>
+			<div class="outer">
+			<table>
+			<?php
+			foreach ($_SERVER['argv'] as $k => $v) echo '<tr><th>', Helpers::escapeHtml($k), '</th><td>', Helpers::escapeHtml($v), "</td></tr>\n";
+			?>
+			</table>
+			</div>
+		</div></div>
+
+
+		<?php else: ?>
 		<div class="panel">
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">HTTP request</a></h2>
 
@@ -322,6 +342,7 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			<p><i>no headers</i></p>
 			<?php endif ?>
 		</div></div>
+		<?php endif ?>
 
 
 		<?php foreach ($bottomPanels as $panel): ?>

--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -298,6 +298,9 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">HTTP request</a></h2>
 
 		<div class="tracy-collapsed inner">
+			<h3>URL</h3>
+			<p><a href="<?= Helpers::escapeHtml($source) ?>"><?= Helpers::escapeHtml($source) ?></a></p>
+
 			<h3>Headers</h3>
 			<div class="outer">
 			<table class="tracy-sortable">

--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -166,7 +166,7 @@ class Helpers
 				. $_SERVER['REQUEST_URI'];
 		} else {
 			return 'CLI (PID: ' . getmypid() . ')'
-				. (empty($_SERVER['argv']) ? '' : ': ' . implode(' ', $_SERVER['argv']));
+				. ': ' . implode(' ', array_map([self::class, 'escapeArg'], $_SERVER['argv']));
 		}
 	}
 
@@ -301,5 +301,20 @@ class Helpers
 		return preg_match('#^Content-Security-Policy(?:-Report-Only)?:.*\sscript-src\s+(?:[^;]+\s)?\'nonce-([\w+/]+=*)\'#mi', implode("\n", headers_list()), $m)
 			? $m[1]
 			: null;
+	}
+
+
+	/**
+	 * Escape a string to be used as a shell argument.
+	 */
+	private static function escapeArg(string $s): string
+	{
+		if (preg_match('#^[a-z0-9._=/:-]+\z#i', $s)) {
+			return $s;
+		}
+
+		return defined('PHP_WINDOWS_VERSION_BUILD')
+			? '"' . str_replace('"', '""', $s) . '"'
+			: escapeshellarg($s);
 	}
 }

--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -184,7 +184,7 @@ class Helpers
 			$replace = ["$m[2](", "$hint("];
 
 		} elseif (preg_match('#^Call to undefined method ([\w\\\\]+)::(\w+)#', $message, $m)) {
-			$hint = self::getSuggestion(get_class_methods($m[1]), $m[2]);
+			$hint = self::getSuggestion(get_class_methods($m[1]) ?: [], $m[2]);
 			$message .= ", did you mean $hint()?";
 			$replace = ["$m[2](", "$hint("];
 

--- a/src/Tracy/TableSort/table-sort.css
+++ b/src/Tracy/TableSort/table-sort.css
@@ -1,0 +1,15 @@
+/**
+ * This file is part of the Tracy (https://tracy.nette.org)
+ */
+
+.tracy-sortable tr:first-child > * {
+	position: relative;
+}
+
+.tracy-sortable tr:first-child > *:hover:before {
+	position: absolute;
+	right: .3em;
+	content: "\21C5";
+	opacity: .4;
+	font-weight: normal;
+}

--- a/tests/Tracy/expected/Debugger.E_ERROR.html.expect
+++ b/tests/Tracy/expected/Debugger.E_ERROR.html.expect
@@ -187,7 +187,7 @@
 		</div></div>
 
 
-		<div class="panel">
+				<div class="panel">
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">HTTP request</a></h2>
 
 		<div class="tracy-collapsed inner">

--- a/tests/Tracy/expected/Debugger.error-in-eval.expect
+++ b/tests/Tracy/expected/Debugger.error-in-eval.expect
@@ -158,7 +158,7 @@
 		</div></div>
 
 
-		<div class="panel">
+				<div class="panel">
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">HTTP request</a></h2>
 
 		<div class="tracy-collapsed inner">

--- a/tests/Tracy/expected/Debugger.exception.html.expect
+++ b/tests/Tracy/expected/Debugger.exception.html.expect
@@ -154,7 +154,7 @@
 		</div></div>
 
 
-		<div class="panel">
+				<div class="panel">
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">HTTP request</a></h2>
 
 		<div class="tracy-collapsed inner">

--- a/tests/Tracy/expected/Debugger.strict.html.expect
+++ b/tests/Tracy/expected/Debugger.strict.html.expect
@@ -161,7 +161,7 @@
 		</div></div>
 
 
-		<div class="panel">
+				<div class="panel">
 		<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">HTTP request</a></h2>
 
 		<div class="tracy-collapsed inner">


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: –

Fixes `Nette\InvalidArgumentException` when compile container with `TracyExtension` bridge.

```php
/** @var PhpGenerator\Method $initialize */
$initialize->addBody('$this->getService(?)->start();', [$name, $name]);
//                                     ^^^                   ^^^^^^^
//                                 placeholder         redundant argument
```

Same Bug in branches:
- `master`
- `v2.6`

Bug born at 1f4271623bfabcb4c887dc7f5b61f64b0438a255.