### PR TITLE
Tracy without session - concept of using files as a storage [WIP]

### DIFF
--- a/src/Tracy/Bar.php
+++ b/src/Tracy/Bar.php
@@ -75,15 +75,16 @@ class Bar
 	 */
 	public function render()
 	{
-		$useSession = $this->useSession && session_status() === PHP_SESSION_ACTIVE;
-		$redirectQueue = &$_SESSION['_tracy']['redirect'];
+		$useSession = $this->useSession && Debugger::getStorage()->isActive();
+		$redirectQueue = Debugger::getStorage()->load('redirect');
 
 		foreach (['bar', 'redirect', 'bluescreen'] as $key) {
-			$queue = &$_SESSION['_tracy'][$key];
+			$queue = Debugger::getStorage()->load($key);
 			$queue = array_slice((array) $queue, -10, null, true);
 			$queue = array_filter($queue, function ($item) {
 				return isset($item['time']) && $item['time'] > time() - 60;
 			});
+			Debugger::getStorage()->save($queue, $key);
 		}
 
 		$rows = [];
@@ -92,7 +93,7 @@ class Bar
 			if ($useSession) {
 				$rows[] = (object) ['type' => 'ajax', 'panels' => $this->renderPanels('-ajax')];
 				$contentId = $_SERVER['HTTP_X_TRACY_AJAX'] . '-ajax';
-				$_SESSION['_tracy']['bar'][$contentId] = ['content' => self::renderHtmlRows($rows), 'dumps' => Dumper::fetchLiveData(), 'time' => time()];
+				Debugger::getStorage()->save(['content' => self::renderHtmlRows($rows), 'dumps' => Dumper::fetchLiveData(), 'time' => time()], 'bar', $contentId);
 			}
 
 		} elseif (preg_match('#^Location:#im', implode("\n", headers_list()))) { // redirect
@@ -117,7 +118,7 @@ class Bar
 			$content = self::renderHtmlRows($rows);
 
 			if ($this->contentId) {
-				$_SESSION['_tracy']['bar'][$this->contentId] = ['content' => $content, 'dumps' => $dumps, 'time' => time()];
+				Debugger::getStorage()->save(['content' => $content, 'dumps' => $dumps, 'time' => time()], 'bar', $this->contentId);
 			} else {
 				$contentId = substr(md5(uniqid('', true)), 0, 10);
 				$nonce = Helpers::getNonce();
@@ -125,6 +126,8 @@ class Bar
 				require __DIR__ . '/assets/Bar/loader.phtml';
 			}
 		}
+
+		Debugger::getStorage()->save($redirectQueue, 'redirect');
 	}
 
 
@@ -206,7 +209,7 @@ class Bar
 		}
 
 		if ($this->useSession && $asset && preg_match('#^content(-ajax)?\.(\w+)$#', $asset, $m)) {
-			$session = &$_SESSION['_tracy']['bar'][$m[2] . $m[1]];
+			$session = Debugger::getStorage()->load('bar', $m[2] . $m[1]);
 			header('Content-Type: application/javascript');
 			header('Cache-Control: max-age=60');
 			header_remove('Set-Cookie');
@@ -216,12 +219,12 @@ class Bar
 			if ($session) {
 				$method = $m[1] ? 'loadAjax' : 'init';
 				echo "Tracy.Debug.$method(", json_encode($session['content']), ', ', json_encode($session['dumps']), ');';
-				$session = null;
+				Debugger::getStorage()->save(null, 'bar', $m[2] . $m[1]);
 			}
-			$session = &$_SESSION['_tracy']['bluescreen'][$m[2]];
+			$session = Debugger::getStorage()->load('bluescreen', $m[2]);
 			if ($session) {
 				echo 'Tracy.BlueScreen.loadAjax(', json_encode($session['content']), ', ', json_encode($session['dumps']), ');';
-				$session = null;
+				Debugger::getStorage()->save(null, 'bluescreen', $m[2]);
 			}
 			return true;
 		}

--- a/src/Tracy/BlueScreen.php
+++ b/src/Tracy/BlueScreen.php
@@ -76,11 +76,11 @@ class BlueScreen
 	 */
 	public function render($exception)
 	{
-		if (Helpers::isAjax() && session_status() === PHP_SESSION_ACTIVE) {
+		if (Helpers::isAjax() && Debugger::getStorage()->isActive()) {
 			ob_start(function () {});
 			$this->renderTemplate($exception, __DIR__ . '/assets/BlueScreen/content.phtml');
 			$contentId = $_SERVER['HTTP_X_TRACY_AJAX'];
-			$_SESSION['_tracy']['bluescreen'][$contentId] = ['content' => ob_get_clean(), 'dumps' => Dumper::fetchLiveData(), 'time' => time()];
+			Debugger::getStorage()->save(['content' => ob_get_clean(), 'dumps' => Dumper::fetchLiveData(), 'time' => time()], 'bluescreen', $contentId);
 
 		} else {
 			$this->renderTemplate($exception, __DIR__ . '/assets/BlueScreen/page.phtml');

--- a/src/Tracy/Debugger.php
+++ b/src/Tracy/Debugger.php
@@ -128,6 +128,9 @@ class Debugger
 	/** @var ILogger */
 	private static $fireLogger;
 
+	/** @var IStorage */
+	private static $storage;
+
 
 	/**
 	 * Static class - cannot be instantiated.
@@ -218,13 +221,8 @@ class Debugger
 				. ($file ? "Output started at $file:$line." : 'Try Tracy\OutputDebugger to find where output started.')
 			);
 
-		} elseif (self::$enabled && session_status() !== PHP_SESSION_ACTIVE) {
-			ini_set('session.use_cookies', '1');
-			ini_set('session.use_only_cookies', '1');
-			ini_set('session.use_trans_sid', '0');
-			ini_set('session.cookie_path', '/');
-			ini_set('session.cookie_httponly', '1');
-			session_start();
+		} elseif (self::$enabled && !self::getStorage()->isActive()) {
+			self::getStorage()->initialize();
 		}
 
 		if (self::getBar()->dispatchAssets()) {
@@ -519,6 +517,27 @@ class Debugger
 			self::$fireLogger = new FireLogger;
 		}
 		return self::$fireLogger;
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public static function setStorage(IStorage $storage)
+	{
+		self::$storage = $storage;
+	}
+
+
+	/**
+	 * @return IStorage
+	 */
+	public static function getStorage()
+	{
+		if (!self::$storage) {
+			self::$storage = new SessionStorage();
+		}
+		return self::$storage;
 	}
 
 

--- a/src/Tracy/FileStorage.php
+++ b/src/Tracy/FileStorage.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tracy;
+
+
+class FileStorage implements IStorage
+{
+	private const COOKIE_NAME = 'tracy-session';
+
+	/** @var string */
+	private $tempDir;
+
+	/** @var string|null */
+	private $storageFilePath;
+
+
+	/**
+	 * @param  string  $tempDir
+	 */
+	public function __construct($tempDir)
+	{
+		if (!is_dir($tempDir)) {
+			throw new \RuntimeException("Temporary directory '{$this->tempDir}' needs to exist.");
+		}
+
+		$this->tempDir = $tempDir;
+
+		if (isset($_COOKIE[self::COOKIE_NAME])) {
+			$sessionId = $_COOKIE[self::COOKIE_NAME];
+		} else {
+			$sessionId = uniqid();
+			setcookie(self::COOKIE_NAME, $sessionId, time() + 7200, '/');
+		}
+
+		$this->storageFilePath = $this->tempDir . DIRECTORY_SEPARATOR . 'tracy-session-' . $sessionId;
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void
+	{
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function isActive()
+	{
+		return true;
+	}
+
+
+	/**
+	 * @param  array        $data
+	 * @param  string       $key1
+	 * @param  string|null  $key2
+	 * @return void
+	 */
+	public function save($data, $key1, $key2 = null)
+	{
+		$lockFile = $this->storageFilePath . '.lock';
+		$lockHandle = $this->lock($lockFile);
+
+		$storageData = $this->loadFromStorage();
+
+		if ($key2 !== null) {
+			$storageData[$key1][$key2] = $data;
+		} else {
+			$storageData[$key1] = $data;
+		}
+
+		file_put_contents($this->storageFilePath, serialize($storageData));
+
+		$this->unlock($lockFile, $lockHandle);
+	}
+
+
+	/**
+	 * @param  string       $key1
+	 * @param  string|null  $key2
+	 * @return array
+	 */
+	public function load($key1, $key2 = null)
+	{
+		$storageData = $this->loadFromStorage();
+
+		if ($key2 !== null) {
+			return $storageData[$key1][$key2] ?? [];
+		}
+
+		return $storageData[$key1] ?? [];
+	}
+
+
+	/**
+	 * @return array
+	 */
+	private function loadFromStorage()
+	{
+		$data = (string) @file_get_contents($this->storageFilePath); // intentionally @
+		return @unserialize($data) ?: []; // intentionally @
+	}
+
+
+	/**
+	 * @param  string  $lockFile
+	 * @return resource
+	 */
+	private function lock($lockFile)
+	{
+		$handle = @fopen($lockFile, 'c+'); // intentionally @
+		if ($handle === FALSE) {
+			throw new \RuntimeException("Unable to create file '$lockFile' " . error_get_last()['message']);
+		} elseif (!@flock($handle, LOCK_EX)) { // intentionally @
+			throw new \RuntimeException("Unable to acquire exclusive lock on '$lockFile' ", error_get_last()['message']);
+		}
+		return $handle;
+	}
+
+
+	/**
+	 * @param  string    $lockFile
+	 * @param  resource  $lockHandle
+	 * @return void
+	 */
+	private function unlock($lockFile, $lockHandle)
+	{
+		@flock($lockHandle, LOCK_UN); // intentionally @
+		@fclose($lockHandle); // intentionally @
+		@unlink($lockFile); // intentionally @
+	}
+}

--- a/src/Tracy/IStorage.php
+++ b/src/Tracy/IStorage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tracy;
+
+
+interface IStorage
+{
+
+	/**
+	 * @return void
+	 */
+	function initialize();
+
+
+	/**
+	 * @return bool
+	 */
+	function isActive();
+
+
+	/**
+	 * @param  array        $data
+	 * @param  string       $key1
+	 * @param  string|null  $key2
+	 * @return void
+	 */
+	function save($data, $key1, $key2 = null);
+
+
+	/**
+	 * @param  string       $key1
+	 * @param  string|null  $key2
+	 * @return array
+	 */
+	function load($key1, $key2 = null);
+}

--- a/src/Tracy/SessionStorage.php
+++ b/src/Tracy/SessionStorage.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tracy;
+
+
+class SessionStorage implements IStorage
+{
+
+	/**
+	 * @return void
+	 */
+	public function initialize()
+	{
+		ini_set('session.use_cookies', '1');
+		ini_set('session.use_only_cookies', '1');
+		ini_set('session.use_trans_sid', '0');
+		ini_set('session.cookie_path', '/');
+		ini_set('session.cookie_httponly', '1');
+		session_start();
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function isActive(): bool
+	{
+		return session_status() === PHP_SESSION_ACTIVE;
+	}
+
+
+	/**
+	 * @param  array        $data
+	 * @param  string       $key1
+	 * @param  string|null  $key2
+	 * @return void
+	 */
+	public function save($data, $key1, $key2 = null): void
+	{
+		if ($key2 !== null) {
+			$_SESSION['_tracy'][$key1][$key2] = $data;
+		} else {
+			$_SESSION['_tracy'][$key1] = $data;
+		}
+	}
+
+
+	/**
+	 * @param  string       $key1
+	 * @param  string|null  $key2
+	 * @return array
+	 */
+	public function load($key1, $key2 = null): array
+	{
+		if ($key2 !== null) {
+			return $_SESSION['_tracy'][$key1][$key2] ?? [];
+		} else {
+			return $_SESSION['_tracy'][$key1] ?? [];
+		}
+	}
+}


### PR DESCRIPTION
- new feature
- issue #356 
- BC break: no

We have a project, where session is started only for logged users. It's a little bit tricky, that Tracy in devel mode always starts session. This could possible hide some bug on devel environment, that is, in better scenario catch with tests, in worse scenario on production :-)

This is just concept, how to let developer choose between session as storage (default and works the same way as now) or file storage. In configuration, you can enable it with setting directory for data files:

```yaml
tracy:
	fileStorage: %tempDir%
```

If this concept will be approved, I can prepare PR for actual Tracy version.