### PR TITLE
Fix bar display in case that user's css rewrites values in body > div

### DIFF
--- a/src/Tracy/Bar/assets/bar.js
+++ b/src/Tracy/Bar/assets/bar.js
@@ -379,7 +379,7 @@
 			(document.body || document.documentElement).appendChild(Debug.layer);
 			evalScripts(Debug.layer);
 			Tracy.Dumper.init(); // for common dump()
-			Debug.layer.style.display = 'block';
+			Debug.layer.style.all = 'initial';
 			Debug.bar.init();
 
 			Debug.layer.querySelectorAll('.tracy-panel').forEach((panel) => {


### PR DESCRIPTION
- bug fix
- BC break? no

In case that css on page manipulates with `body > div {}` (for instance, width/height), tracy bar would be affected, so bar wrapper now contains `all: initial` in element style.
