### PR TITLE
Add support for escaping (for example in json).

### DIFF
--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -110,7 +110,7 @@ class BlueScreen
 	private function renderTemplate(\Throwable $exception, string $template, $toScreen = true): void
 	{
 		$messageHtml = preg_replace(
-			'#\'\S[^\']*\S\'|"\S[^"]*\S"#U',
+			'#\'\S(?:[^\']|\\\\\')*\S\'|"\S(?:[^"]|\\\\")*\S"#',
 			'<i>$0</i>',
 			htmlspecialchars((string) $exception->getMessage(), ENT_SUBSTITUTE, 'UTF-8')
 		);


### PR DESCRIPTION
- bug fix
- BC break? yes

Original regex does not support json syntax with escaping in message highliter.

Example:

<img width="713" alt="Snímek obrazovky 2019-04-20 v 12 11 07" src="https://user-images.githubusercontent.com/4738758/56456073-6479dc80-6367-11e9-8e8b-5d128ff55ea8.png">

New pattern support quotation escaping:

<img width="839" alt="Snímek obrazovky 2019-04-20 v 12 20 28" src="https://user-images.githubusercontent.com/4738758/56456079-8b381300-6367-11e9-98f7-1c50249f0bb3.png">