### PR TITLE
PsrToTracyLoggerAdapter: changed the log message

### DIFF
--- a/src/Bridges/Psr/PsrToTracyLoggerAdapter.php
+++ b/src/Bridges/Psr/PsrToTracyLoggerAdapter.php
@@ -41,7 +41,7 @@ class PsrToTracyLoggerAdapter implements Tracy\ILogger
 	public function log($value, string $priority = self::INFO)
 	{
 		if ($value instanceof \Throwable) {
-			$message = $value->getMessage();
+			$message = Tracy\Helpers::getClass($value) . ': ' . $value->getMessage() . ($value->getCode() ? ' #' . $value->getCode() : '') . ' in ' . $value->getFile() . ':' . $value->getLine();
 			$context = ['exception' => $value];
 
 		} elseif (!is_string($value)) {

--- a/tests/Tracy.Bridges/PsrToTracyLoggerAdapter.phpt
+++ b/tests/Tracy.Bridges/PsrToTracyLoggerAdapter.phpt
@@ -28,7 +28,7 @@ class DummyPsrLogger extends Psr\Log\AbstractLogger
 
 $psrLogger = new DummyPsrLogger;
 $tracyLogger = new PsrToTracyLoggerAdapter($psrLogger);
-$exception = new \Exception('Something went wrong');
+$exception = new \Exception('Something went wrong', 123);
 
 $tracyLogger->log('info');
 $tracyLogger->log('warning', ILogger::WARNING);
@@ -41,5 +41,5 @@ Assert::same([
 	[Psr\Log\LogLevel::WARNING, 'warning', []],
 	[Psr\Log\LogLevel::INFO, '123', []],
 	[Psr\Log\LogLevel::INFO, "array (1)\n   x => \"y\"", []],
-	[Psr\Log\LogLevel::INFO, 'Something went wrong', ['exception' => $exception]],
+	[Psr\Log\LogLevel::INFO, 'Exception: Something went wrong #123 in ' . __DIR__ . DIRECTORY_SEPARATOR . 'PsrToTracyLoggerAdapter.phpt:31', ['exception' => $exception]],
 ], $psrLogger->entries);


### PR DESCRIPTION
- new feature
- BC break? no

Some loggers (e.g https://github.com/bzikarsky/gelf-php) may require a non-empty log message. Adding the exception class, code and file to the log message solves this problem.

