### PR TITLE
Increase size of memory reserve for Debugger

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -152,7 +152,7 @@ class Debugger
 			self::$productionMode = is_bool($mode) ? $mode : !self::detectDebugMode($mode);
 		}
 
-		self::$reserved = str_repeat('t', 30000);
+		self::$reserved = str_repeat('t', 500000);
 		self::$time = $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true);
 		self::$obLevel = ob_get_level();
 		self::$cpuUsage = !self::$productionMode && function_exists('getrusage') ? getrusage() : null;


### PR DESCRIPTION
The value of 30000 bytes was an incorrect representation of the previous "scientific notation value" of "3e5". I can only assume the notation was changed to increase readability, but the change was done improperly and introduced a regression.

Also the number of bytes reserved for the error renderer was increased to 500 kB, since 300 kBs wasn't enough for the whole error page to render correctly.

- bug fix for issue: *Catching memory exhaustion #272*
- BC break? *Shouldn't be...*

## Before
![image](https://user-images.githubusercontent.com/6860713/58366539-2591f600-7ed4-11e9-927a-732844563eaf.png)
## After
![image](https://user-images.githubusercontent.com/6860713/58366542-288ce680-7ed4-11e9-80bd-c25a63e5ad46.png)
