### PR TITLE
InfoPanel: Add information about localhost IP.

### DIFF
--- a/src/Tracy/Bar/panels/info.panel.phtml
+++ b/src/Tracy/Bar/panels/info.panel.phtml
@@ -25,6 +25,13 @@ $countClasses = function (array $list): int {
 	}));
 };
 
+$ipFormatter = static function (?string $ip): ?string {
+	if ($ip === '127.0.0.1' || $ip === '::1') {
+		$ip .= ' (localhost)';
+	}
+	return $ip;
+};
+
 $opcache = function_exists('opcache_get_status') ? @opcache_get_status() : null; // @ can be restricted
 $cachedFiles = isset($opcache['scripts']) ? array_intersect(array_keys($opcache['scripts']), get_included_files()) : [];
 
@@ -36,8 +43,8 @@ $info = [
 	'OPcache' => $opcache ? round(count($cachedFiles) * 100 / count(get_included_files())) . '% cached' : null,
 	'Classes + interfaces + traits' => $countClasses(get_declared_classes()) . ' + '
 		. $countClasses(get_declared_interfaces()) . ' + ' . $countClasses(get_declared_traits()),
-	'Your IP' => $_SERVER['REMOTE_ADDR'] ?? null,
-	'Server IP' => $_SERVER['SERVER_ADDR'] ?? null,
+	'Your IP' => $ipFormatter($_SERVER['REMOTE_ADDR'] ?? null),
+	'Server IP' => $ipFormatter($_SERVER['SERVER_ADDR'] ?? null),
 	'HTTP method / response code' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] . ' / ' . http_response_code() : null,
 	'PHP' => PHP_VERSION,
 	'Xdebug' => extension_loaded('xdebug') ? phpversion('xdebug') : null,


### PR DESCRIPTION
- new feature
- BC break? no

Sometimes beginners have a problem understanding that `127.0.0.1` or `::1` is localhost.

I think Tracy should explain it in brackets:

![Snímek obrazovky 2019-08-10 v 22 04 22](https://user-images.githubusercontent.com/4738758/62826389-e3b34a80-bbba-11e9-8756-3c472f309de2.png)

Thanks.