### PR TITLE
Bridge: Remove redundant <pre> and <div>.

### DIFF
--- a/src/Bridges/Nette/Bridge.php
+++ b/src/Bridges/Nette/Bridge.php
@@ -43,9 +43,7 @@ class Bridge
 								? '<b>File:</b> ' . Helpers::editorLink($e->sourceName, $e->sourceLine)
 								: '<b>' . htmlspecialchars($e->sourceName . ($e->sourceLine ? ':' . $e->sourceLine : '')) . '</b>')
 							. '</p>')
-					. '<pre class=code><div>'
-					. BlueScreen::highlightLine(htmlspecialchars($e->sourceCode, ENT_IGNORE, 'UTF-8'), $e->sourceLine)
-					. '</div></pre>',
+					. BlueScreen::highlightLine(htmlspecialchars($e->sourceCode, ENT_IGNORE, 'UTF-8'), $e->sourceLine),
 			];
 
 		} elseif ($e && strpos($file = $e->getFile(), '.latte--')) {
@@ -58,7 +56,7 @@ class Bridge
 					'panel' => '<p><b>File:</b> ' . Helpers::editorLink($templateFile, $templateLine) . '</p>'
 						. ($templateLine === null
 							? ''
-							: '<pre class="code"><div>' . BlueScreen::highlightFile($templateFile, $templateLine) . '</div></pre>'),
+							: BlueScreen::highlightFile($templateFile, $templateLine)),
 				];
 			}
 		}


### PR DESCRIPTION
- bug fix
- BC break? no

In case of Latte error in template render multiple of border. Now fixed.

Old render style:

<img width="640" alt="Snímek obrazovky 2019-08-29 v 15 59 59" src="https://user-images.githubusercontent.com/4738758/63947131-ac77e100-ca76-11e9-8714-c1d3eb14eff3.png">

New style:

<img width="574" alt="Snímek obrazovky 2019-08-29 v 16 02 51" src="https://user-images.githubusercontent.com/4738758/63947147-b39eef00-ca76-11e9-800f-81ce1a45b21f.png">

Thanks.