### PR TITLE
Bridge: Template line can be null.

### DIFF
--- a/src/Bridges/Nette/Bridge.php
+++ b/src/Bridges/Nette/Bridge.php
@@ -52,7 +52,7 @@ class Bridge
 			$lines = file($file);
 			if (preg_match('#// source: (\S+\.latte)#', $lines[1], $m) && @is_file($m[1])) { // @ - may trigger error
 				$templateFile = $m[1];
-				$templateLine = preg_match('#/\* line (\d+) \*/#', $lines[$e->getLine() - 1], $m) ? (int) $m[1] : null;
+				$templateLine = preg_match('#/\* line (\d+) \*/#', $lines[$e->getLine() - 1] ?? '', $m) ? (int) $m[1] : null;
 				return [
 					'tab' => 'Template',
 					'panel' => '<p><b>File:</b> ' . Helpers::editorLink($templateFile, $templateLine) . '</p>'

--- a/src/Bridges/Nette/Bridge.php
+++ b/src/Bridges/Nette/Bridge.php
@@ -52,7 +52,7 @@ class Bridge
 			$lines = file($file);
 			if (preg_match('#// source: (\S+\.latte)#', $lines[1], $m) && @is_file($m[1])) { // @ - may trigger error
 				$templateFile = $m[1];
-				$templateLine = preg_match('#/\* line (\d+) \*/#', $lines[$e->getLine() - 1] ?? '', $m) ? (int) $m[1] : null;
+				$templateLine = $e->getLine() && preg_match('#/\* line (\d+) \*/#', $lines[$e->getLine() - 1], $m) ? (int) $m[1] : null;
 				return [
 					'tab' => 'Template',
 					'panel' => '<p><b>File:</b> ' . Helpers::editorLink($templateFile, $templateLine) . '</p>'


### PR DESCRIPTION
- bug fix
- BC break? no

In case of template error line is null Tracy can not render filename:

<img width="1388" alt="Snímek obrazovky 2019-09-12 v 17 06 13" src="https://user-images.githubusercontent.com/4738758/64796641-4b750080-d580-11e9-9d95-bacf1e840483.png">

Fixed to:

<img width="1527" alt="Snímek obrazovky 2019-09-12 v 17 10 22" src="https://user-images.githubusercontent.com/4738758/64796665-5465d200-d580-11e9-9909-a947ab798b81.png">
