### PR TITLE
BlueScreen HTTP Request: Add support for rendering PHP Input

### DIFF
--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -309,6 +309,18 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			</table>
 			</div>
 
+			<?php
+			if (($phpInput = (string) file_get_contents('php://input')) !== ''):
+			?>
+			<h3>PHP Input</h3>
+			<pre class="code"><?= Helpers::escapeHtml($phpInput) ?></pre>
+			<?php
+			if (strlen($phpInput) < 10000 && preg_match('/^\{.*\}$/', $phpInput)) {
+		  	echo $dump(json_decode($phpInput, true));
+			}
+			endif
+			?>
+
 
 			<?php foreach (['_GET', '_POST', '_COOKIE'] as $name): ?>
 			<h3>$<?= Helpers::escapeHtml($name) ?></h3>

--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -310,12 +310,12 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			</div>
 
 			<?php
-			if (($phpInput = (string) file_get_contents('php://input')) !== ''):
+			if (($phpInput = (string) file_get_contents('php://input', false, null, 0, 10000)) !== ''):
 			?>
 			<h3>PHP Input</h3>
 			<pre class="code"><?= Helpers::escapeHtml($phpInput) ?></pre>
 			<?php
-			if (strlen($phpInput) < 10000 && preg_match('/^\{.*\}$/', $phpInput)) {
+			if (strlen($phpInput) < 9500 && strncmp($httpHeaders['Content-Type'] ?? '', 'application/json', 16) === 0) {
 		  	echo $dump(json_decode($phpInput, true));
 			}
 			endif


### PR DESCRIPTION
- new feature
- BC break? yes

If request was called as ajax json payload with some data but without `'Content-Type': 'application/x-www-form-urlencoded'` header, Tracy can not dump sent values.

This change add automatic detection of `PHP Input` and render to `HTTP request` section.

Example:

![Snímek obrazovky 2019-11-01 v 12 12 52](https://user-images.githubusercontent.com/4738758/68021177-fbbdd600-fca0-11e9-94e6-12212a29c09b.png)

If entered data was short json, Tracy will detect it automatically and dump as array for bette readability.

More information (Czech language): https://php.baraja.cz/ajax-post

Thanks.