### PR TITLE
Debugger::log(), parameter $level can be null

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -567,9 +567,9 @@ class Debugger
 	 * @param  mixed  $message
 	 * @return mixed
 	 */
-	public static function log($message, string $level = ILogger::INFO)
+	public static function log($message, ?string $level = null)
 	{
-		return self::getLogger()->log($message, $level);
+		return self::getLogger()->log($message, $level ?? ($message instanceof \Exception ? ILogger::EXCEPTION : ILogger::INFO));
 	}
 
 


### PR DESCRIPTION
- new feature?
- BC break? yes

I think second parameter of `Debugger::log()` can be null.

In case of simple call `Debugger::log($e);` in user code Tracy should log it as `Exception` level and in case of `Debugger::log('Message');` as default `Info`.

It can be detected by `nullable` default value.