### PR TITLE
Info panel: Add server name by IP

### DIFF
--- a/src/Tracy/Bar/panels/info.panel.phtml
+++ b/src/Tracy/Bar/panels/info.panel.phtml
@@ -44,7 +44,8 @@ $info = [
 	'Classes + interfaces + traits' => $countClasses(get_declared_classes()) . ' + '
 		. $countClasses(get_declared_interfaces()) . ' + ' . $countClasses(get_declared_traits()),
 	'Your IP' => $ipFormatter($_SERVER['REMOTE_ADDR'] ?? null),
-	'Server IP' => $ipFormatter($_SERVER['SERVER_ADDR'] ?? null),
+	'Server IP' => $ipFormatter($serverIp = $_SERVER['SERVER_ADDR'] ?? null),
+	'Server name' => $serverIp !== null && $serverIp !== '127.0.0.1' && $serverIp !== '::1' ? gethostbyaddr($serverIp) : 'localhost',
 	'HTTP method / response code' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] . ' / ' . http_response_code() : null,
 	'PHP' => PHP_VERSION,
 	'Xdebug' => extension_loaded('xdebug') ? phpversion('xdebug') : null,


### PR DESCRIPTION
- new feature
- BC break? yes

Very often I need to find out what production server the site is running on. This feature should be very useful.