### PR TITLE
Info panel: When server IP is localhost add warning.

### DIFF
--- a/src/Tracy/Bar/panels/info.panel.phtml
+++ b/src/Tracy/Bar/panels/info.panel.phtml
@@ -32,6 +32,13 @@ $ipFormatter = static function (?string $ip): ?string {
 	return $ip;
 };
 
+$serverNameFormatter = static function(string $userIp, string $serverIp): string {
+	if ($serverIp !== '127.0.0.1' && $serverIp !== '::1') {
+		return gethostbyaddr($serverIp);
+	}
+	return 'localhost' . ($userIp !== '127.0.0.1' && $userIp !== '::1' ? ' (may not be true)' : '');
+};
+
 $opcache = function_exists('opcache_get_status') ? @opcache_get_status() : null; // @ can be restricted
 $cachedFiles = isset($opcache['scripts']) ? array_intersect(array_keys($opcache['scripts']), get_included_files()) : [];
 
@@ -43,9 +50,9 @@ $info = [
 	'OPcache' => $opcache ? round(count($cachedFiles) * 100 / count(get_included_files())) . '% cached' : null,
 	'Classes + interfaces + traits' => $countClasses(get_declared_classes()) . ' + '
 		. $countClasses(get_declared_interfaces()) . ' + ' . $countClasses(get_declared_traits()),
-	'Your IP' => $ipFormatter($_SERVER['REMOTE_ADDR'] ?? null),
+	'Your IP' => $ipFormatter($userIp = $_SERVER['REMOTE_ADDR'] ?? null),
 	'Server IP' => $ipFormatter($serverIp = $_SERVER['SERVER_ADDR'] ?? null),
-	'Server name' => $serverIp !== null && $serverIp !== '127.0.0.1' && $serverIp !== '::1' ? gethostbyaddr($serverIp) : 'localhost',
+	'Server name' => $serverNameFormatter($userIp ?? '127.0.0.1', $serverIp ?? '127.0.0.1'),
 	'HTTP method / response code' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] . ' / ' . http_response_code() : null,
 	'PHP' => PHP_VERSION,
 	'Xdebug' => extension_loaded('xdebug') ? phpversion('xdebug') : null,

--- a/src/Tracy/Bar/panels/info.panel.phtml
+++ b/src/Tracy/Bar/panels/info.panel.phtml
@@ -36,7 +36,7 @@ $serverNameFormatter = static function(string $userIp, string $serverIp): string
 	if ($serverIp !== '127.0.0.1' && $serverIp !== '::1') {
 		return gethostbyaddr($serverIp);
 	}
-	return 'localhost' . ($userIp !== '127.0.0.1' && $userIp !== '::1' ? ' (may not be true)' : '');
+	return 'localhost' . (preg_match('/^127\.0\.0\.\d{1,3}|::1$/', $userIp) ? ' (may not be true)' : '');
 };
 
 $opcache = function_exists('opcache_get_status') ? @opcache_get_status() : null; // @ can be restricted


### PR DESCRIPTION
- new feature
- BC break? yes

Sometimes server IP can be `127.0.0.1`, because server admin make mistake in configuration.

For instance:

![Snímek obrazovky 2020-01-29 v 16 27 49](https://user-images.githubusercontent.com/4738758/73370306-4b1d9d80-42b4-11ea-806b-d78b11a9ca97.png)

This feature add warning message like Tracy in argument block.