### PR TITLE
Logger: Remove shut-up marker on date()

### DIFF
--- a/src/Tracy/Logger/Logger.php
+++ b/src/Tracy/Logger/Logger.php
@@ -111,7 +111,7 @@ class Logger implements ILogger
 	public static function formatLogLine($message, string $exceptionFile = null): string
 	{
 		return implode(' ', [
-			@date('[Y-m-d H-i-s]'), // @ timezone may not be set
+			date('[Y-m-d H-i-s]'),
 			preg_replace('#\s*\r?\n\s*#', ' ', static::formatMessage($message)),
 			' @  ' . Helpers::getSource(),
 			$exceptionFile ? ' @@  ' . basename($exceptionFile) : null,
@@ -135,7 +135,7 @@ class Logger implements ILogger
 				return $dir . $file;
 			}
 		}
-		return $dir . $level . '--' . @date('Y-m-d--H-i') . "--$hash.html"; // @ timezone may not be set
+		return $dir . $level . '--' . date('Y-m-d--H-i') . "--$hash.html";
 	}
 
 


### PR DESCRIPTION
PHP 7+ no more thrown warning when timezone not set.

- new feature
- BC break? no
- doc PR: not needed

## Description
- Nette Tracy is required PHP 7 +
- PHP 7 is no mote throw warning on using `date`-like functions without defined current TimeZone
- Silent error marker on `@date()` function is no more needed.

## Sources
- https://hakre.wordpress.com/2016/01/03/history-of-the-php-date-timezone-settings-warning/
- https://github.com/php/php-src/pull/1029

Thanks for this great tool ❤️
