### PR TITLE
Bridge: When template line is null, ignore whole Template section.

### DIFF
--- a/src/Bridges/Nette/Bridge.php
+++ b/src/Bridges/Nette/Bridge.php
@@ -52,13 +52,13 @@ class Bridge
 			$lines = file($file);
 			if (preg_match('#// source: (\S+\.latte)#', $lines[1], $m) && @is_file($m[1])) { // @ - may trigger error
 				$templateFile = $m[1];
-				$templateLine = $e->getLine() && preg_match('#/\* line (\d+) \*/#', $lines[$e->getLine() - 1], $m) ? (int) $m[1] : 0;
+				if (($templateLine = $e->getLine() && preg_match('#/\* line (\d+) \*/#', $lines[$e->getLine() - 1], $m) ? (int) $m[1] : null) === null) {
+					return null;
+				}
 				return [
 					'tab' => 'Template',
 					'panel' => '<p><b>File:</b> ' . Helpers::editorLink($templateFile, $templateLine) . '</p>'
-						. ($templateLine === null
-							? ''
-							: BlueScreen::highlightFile($templateFile, $templateLine)),
+						. BlueScreen::highlightFile($templateFile, $templateLine),
 				];
 			}
 		}

--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -359,7 +359,7 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 		<footer>
 			<ul>
 				<li><b><a href="https://nette.org/make-donation?to=tracy" target="_blank" rel="noreferrer noopener">Please support Tracy via a donation 💙️</a></b></li>
-				<li>Report generated at <?= @date('Y/m/d H:i:s') // @ timezone may not be set ?></li>
+				<li>Report generated at <?= date('Y/m/d H:i:s') ?></li>
 				<?php foreach ($info as $item): ?><li><?= Helpers::escapeHtml($item) ?></li><?php endforeach ?>
 			</ul>
 			<div class="footer-logo"><a href="https://tracy.nette.org" rel="noreferrer"></a></div>

--- a/src/Tracy/Debugger/assets/error.500.phtml
+++ b/src/Tracy/Debugger/assets/error.500.phtml
@@ -32,7 +32,7 @@ namespace Tracy;
 		<p>We're sorry! The server encountered an internal error and
 		was unable to complete your request. Please try again later.</p>
 
-		<p><small>error 500 <span> | <?php echo @date('j. n. Y H:i') ?></span><?php if (!$logged): ?><br>Tracy is unable to log error.<?php endif ?></small></p>
+		<p><small>error 500 <span> | <?php echo date('j. n. Y H:i') ?></span><?php if (!$logged): ?><br>Tracy is unable to log error.<?php endif ?></small></p>
 	</div>
 </div>
 

--- a/src/Tracy/Logger/Logger.php
+++ b/src/Tracy/Logger/Logger.php
@@ -111,7 +111,7 @@ class Logger implements ILogger
 	public static function formatLogLine($message, string $exceptionFile = null): string
 	{
 		return implode(' ', [
-			@date('[Y-m-d H-i-s]'), // @ timezone may not be set
+			date('[Y-m-d H-i-s]'),
 			preg_replace('#\s*\r?\n\s*#', ' ', static::formatMessage($message)),
 			' @  ' . Helpers::getSource(),
 			$exceptionFile ? ' @@  ' . basename($exceptionFile) : null,
@@ -135,7 +135,7 @@ class Logger implements ILogger
 				return $dir . $file;
 			}
 		}
-		return $dir . $level . '--' . @date('Y-m-d--H-i') . "--$hash.html"; // @ timezone may not be set
+		return $dir . $level . '--' . date('Y-m-d--H-i') . "--$hash.html";
 	}
 
 
@@ -159,7 +159,7 @@ class Logger implements ILogger
 	{
 		$snooze = is_numeric($this->emailSnooze)
 			? $this->emailSnooze
-			: @strtotime($this->emailSnooze) - time(); // @ timezone may not be set
+			: strtotime($this->emailSnooze) - time();
 
 		if (
 			$this->email


### PR DESCRIPTION
- bug fix
- BC break? yes

I think in case when I can not detect position of error, template section should be ignored.

Current behavior:

![Snímek obrazovky 2020-02-12 v 16 39 02](https://user-images.githubusercontent.com/4738758/74350571-2ea25a80-4db6-11ea-988e-0a8c6cb13f12.png)

New behavior:

![Snímek obrazovky 2020-02-12 v 16 38 40](https://user-images.githubusercontent.com/4738758/74350523-21856b80-4db6-11ea-9bc9-1c1640ff30ec.png)

Thanks.