### PR TITLE
Info panel: Better detection server IP and server name.

### DIFF
--- a/src/Tracy/Bar/panels/info.panel.phtml
+++ b/src/Tracy/Bar/panels/info.panel.phtml
@@ -44,8 +44,8 @@ $info = [
 	'Classes + interfaces + traits' => $countClasses(get_declared_classes()) . ' + '
 		. $countClasses(get_declared_interfaces()) . ' + ' . $countClasses(get_declared_traits()),
 	'Your IP' => $ipFormatter($_SERVER['REMOTE_ADDR'] ?? null),
-	'Server IP' => $ipFormatter($serverIp = $_SERVER['SERVER_ADDR'] ?? null),
-	'Server name' => $serverIp !== null && $serverIp !== '127.0.0.1' && $serverIp !== '::1' ? gethostbyaddr($serverIp) : 'localhost',
+	'Server IP' => $ipFormatter(gethostbyname($serverName = php_uname('n'))),
+	'Server name' => $serverName,
 	'HTTP method / response code' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] . ' / ' . http_response_code() : null,
 	'PHP' => PHP_VERSION,
 	'Xdebug' => extension_loaded('xdebug') ? phpversion('xdebug') : null,


### PR DESCRIPTION
- bug fix
- BC break? no

I think this is more better way how to detect real server IP and real server name. Supports simple server architecture and Ngnix as reverse proxy.

Explanation: https://php.baraja.cz/ip-adresa (czech language).

<img width="398" alt="Snímek obrazovky 2020-02-28 v 10 38 35" src="https://user-images.githubusercontent.com/4738758/75536986-79f37480-5a16-11ea-8825-5533e6590514.png">

Thanks.