### PR TITLE
Toggle bar panels: added functionality for toggling  bar panels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,6 +271,34 @@ bdump([1, 3, 5, 7, 9], 'odd numbers up to ten');
 ![bar dump](https://nette.github.io/tracy/images/tracy-bardump.png)
 
 
+Toggling
+------
+
+Tracy can sometimes overlap bottom of modals where the submit buttons are often located. This can occur e.g. when displaying the developer console, which reduces the height of the window and moves the dialog to the bottom of the page where Tracy has the default position. By enabling `toggleBarPanels` you can minimize Tracy bar instead of closing it what can be handy often.
+
+Configuration example for enable toggling:
+
+```neon
+tracy:
+	toggleBarPanels:
+		show: true
+```
+
+We can add exceptions for hiding panels:
+
+```neon
+tracy:
+	toggleBarPanels:
+		show: true
+		exclude:
+			- Tracy-dumps
+			- Nette-Bridges-DatabaseTracy-ConnectionPanel
+```
+
+Items in exclude array matches part of the `rel` attribute value in the panel. 
+E.g. string 'Tracy-dumps' activates an exception for the panel with the `rel` attribute value 'tracy-debug-panel-Tracy-dumps' in the main bar. For the others (ajax, redirect) it matches 'tracy-debug-panel-Tracy-dumps-...'
+
+
 Timing
 ------
 

--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -36,6 +36,7 @@ class TracyExtension extends Nette\DI\CompilerExtension
 		'blueScreen' => [], // of callback
 		'editorMapping' => [],
 		'netteMailer' => true,
+		'toggleBarPanels' => [],
 	];
 
 	/** @var bool */

--- a/src/Tracy/Bar/assets/bar.css
+++ b/src/Tracy/Bar/assets/bar.css
@@ -232,7 +232,6 @@ body#tracy-debug { /* in popup window */
 	margin: 0 .2em 0 .5em;
 }
 
-
 /* panels */
 #tracy-debug .tracy-panel {
 	display: none;

--- a/src/Tracy/Bar/assets/bar.phtml
+++ b/src/Tracy/Bar/assets/bar.phtml
@@ -32,6 +32,17 @@ namespace Tracy;
 <?php } endforeach ?>
 
 <?php if ($type === 'main'): ?>
+	<?php if (Debugger::$toggleBarPanels && isset(Debugger::$toggleBarPanels['show']) && Debugger::$toggleBarPanels['show']): ?>
+		<li class="tracy-bar-toggler">
+			<a
+				href="#"
+				rel="toggle"
+				data-title-maximize="maximize debug bar"
+				data-title-minimize="minimize debug bar"
+				data-excluded-panels="<?= htmlspecialchars(json_encode(Debugger::$toggleBarPanels['exclude'] ?? [])) ?>"
+			></a>
+		</li>
+	<?php endif ?>
 	<li><a href="#" rel="close" title="close debug bar">&times;</a></li>
 <?php endif ?>
 </ul>

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -119,6 +119,12 @@ class Debugger
 	/** @var array|null */
 	private static $cpuUsage;
 
+	/** @var array */
+	public static $toggleBarPanels = [
+		'show' => false, // bool, whether to display plus/minus icons
+		'exclude' => [], // string[], which bar panels should be ignored while toggle
+	];
+
 	/********************* services ****************d*g**/
 
 	/** @var BlueScreen */


### PR DESCRIPTION
- new feature
- BC break? no


Tracy can sometimes overlap bottom of modals where the submit buttons are often located. This can occur e.g. when displaying the developer console, which reduces the height of the window and moves the dialog to the bottom of the page where Tracy has the default position. By enabling `toggleBarPanels` you can minimize Tracy bar instead of closing it what can be handy often.

Configuration example for enable toggling:

```neon
tracy:
	toggleBarPanels:
		show: true
```

_Tracy bar default state:_
![image](https://user-images.githubusercontent.com/20837611/80685353-62dd0b80-8ac7-11ea-8034-b0453ab01b97.png)

_Tracy bar collapsed:_
![image](https://user-images.githubusercontent.com/20837611/80685265-36c18a80-8ac7-11ea-9a95-b65766404008.png)


We can add exceptions for hiding panels:

```neon
tracy:
	toggleBarPanels:
		show: true
		exclude:
			- Tracy-dumps
			- Nette-Bridges-DatabaseTracy-ConnectionPanel
```

_Tracy bar collapsed:_
![image](https://user-images.githubusercontent.com/20837611/80690942-d1be6280-8acf-11ea-824f-2a911d113730.png)

