### PR TITLE
bar.js: fetch checks Response

### DIFF
--- a/src/Tracy/Bar/assets/bar.js
+++ b/src/Tracy/Bar/assets/bar.js
@@ -493,7 +493,7 @@ class Debug
 				let reqId = header + '_' + ajaxCounter++;
 				request.headers.set('X-Tracy-Ajax', reqId);
 				return oldFetch(request).then((response) => {
-					if (response.headers.has('X-Tracy-Ajax') && response.headers.get('X-Tracy-Ajax')[0] === '1') {
+					if (response instanceof Response && response.headers.has('X-Tracy-Ajax') && response.headers.get('X-Tracy-Ajax')[0] === '1') {
 						Debug.loadScript(baseUrl + '_tracy_bar=content-ajax.' + reqId + '&XDEBUG_SESSION_STOP=1&v=' + Math.random());
 					}
 


### PR DESCRIPTION
In project I am currently working on, I also wrap `fetch()` method and return the result as `json` object, but tracy doesn't check if the response is actually a Response object.

So it thinks my json object is `Response` object and tries to access `.headers` property, that may not exist and then run function `has()` on it.

- bug fix
- BC break? no
