### PR TITLE
Allow to hide the Environment section by configuration

### DIFF
--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -35,6 +35,9 @@ class BlueScreen
 	/** @var string[] */
 	public $keysToHide = ['password', 'passwd', 'pass', 'pwd', 'creditcard', 'credit card', 'cc', 'pin'];
 
+	/** @var bool */
+	public $showEnvironment = true;
+
 	/** @var callable[] */
 	private $panels = [];
 
@@ -119,7 +122,7 @@ class BlueScreen
 
 	private function renderTemplate(\Throwable $exception, string $template, $toScreen = true): void
 	{
-		$showEnvironment = strpos($exception->getMessage(), 'Allowed memory size') === false;
+		$showEnvironment = $this->showEnvironment && (strpos($exception->getMessage(), 'Allowed memory size') === false);
 		$messageHtml = $this->formatMessage($exception);
 		$info = array_filter($this->info);
 		$source = Helpers::getSource();

--- a/tests/Tracy/BlueScreen.showEnvironment.phpt
+++ b/tests/Tracy/BlueScreen.showEnvironment.phpt
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$blueScreen = new Tracy\BlueScreen;
+
+$render = function ($exception) use ($blueScreen) {
+	ob_start();
+	$blueScreen->render($exception);
+	try {
+		return ob_get_contents();
+	} finally {
+		ob_end_clean();
+	}
+};
+
+$exception = new Exception('foo');
+
+$lookFor = '<h2><a data-tracy-ref="^+" class="tracy-toggle tracy-collapsed">Environment</a></h2>';
+
+// sanity test: The environment section is present in the rendered string
+$c = $render($exception);
+Assert::true(strpos($c, $lookFor) !== false);
+
+// on memory failures, it's hidden by default:
+$c = $render($hohoh = new ErrorException('Fatal Error: Allowed memory size of 134217728 bytes exhausted'));
+Assert::true(strpos($c, $lookFor) === false);
+
+// this time the section is absent:
+$blueScreen->showEnvironment = false;
+$c = $render($exception);
+Assert::true(strpos($c, $lookFor) === false);


### PR DESCRIPTION
This is a new feature that allows us to omit the Environent section from the output.

```php
// hide the environment section (shown by default)
Tracy\Debugger::getBlueScreen()->showEnvironment = false;
```

This refers to #430 issue.