### PR TITLE
Scrubber mechanism

### DIFF
--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -29,6 +29,9 @@ class BlueScreen
 	/** @var int  */
 	public $maxLength = 150;
 
+	/** @var callable|null  a callable returning TRUE for sensitive data; fn(string $key, mixed $val = null): bool */
+	public $scrubber;
+
 	/** @var string[] */
 	public $keysToHide = ['password', 'passwd', 'pass', 'pwd', 'creditcard', 'credit card', 'cc', 'pin'];
 
@@ -360,9 +363,12 @@ class BlueScreen
 	public function getDumper(): \Closure
 	{
 		$keysToHide = array_flip(array_map('strtolower', $this->keysToHide));
+		$scrubber = $this->scrubber ?? function (string $k) use ($keysToHide): bool {
+			return isset($keysToHide[strtolower($k)]);
+		};
 
-		return function ($v, $k = null) use ($keysToHide): string {
-			if (is_string($k) && isset($keysToHide[strtolower($k)])) {
+		return function ($v, $k = null) use ($scrubber): string {
+			if (is_string($k) && $scrubber($k, $v)) {
 				$v = Dumper::HIDDEN_VALUE;
 			}
 			return Dumper::toHtml($v, [
@@ -370,7 +376,7 @@ class BlueScreen
 				Dumper::TRUNCATE => $this->maxLength,
 				Dumper::SNAPSHOT => &$this->snapshot,
 				Dumper::LOCATION => Dumper::LOCATION_CLASS,
-				Dumper::KEYS_TO_HIDE => $this->keysToHide,
+				Dumper::SCRUBBER => $scrubber,
 			]);
 		};
 	}

--- a/src/Tracy/Dumper/Describer.php
+++ b/src/Tracy/Dumper/Describer.php
@@ -38,6 +38,9 @@ final class Describer
 	/** @var array */
 	public $keysToHide = [];
 
+	/** @var callable|null */
+	public $scrubber;
+
 	/** @var bool */
 	public $location = false;
 
@@ -159,7 +162,7 @@ final class Describer
 			$refId = $this->getReferenceId($arr, $k);
 			$items[] = [
 				$this->describeVar($k, $depth + 1),
-				is_string($k) && isset($this->keysToHide[strtolower($k)])
+				is_string($k) && $this->isSensitive($k, $v)
 					? new Value(Value::TYPE_TEXT, self::hideValue($v))
 					: $this->describeVar($v, $depth + 1, $refId),
 			] + ($refId ? [2 => $refId] : []);
@@ -238,10 +241,19 @@ final class Describer
 			$value->length = ($value->length ?? count($value->items)) + 1;
 			return;
 		}
-		$v = isset($this->keysToHide[strtolower($k)])
+		$v = $this->isSensitive($k, $v)
 			? new Value(Value::TYPE_TEXT, self::hideValue($v))
 			: $this->describeVar($v, $value->depth + 1, $refId);
 		$value->items[] = [$this->describeKey($k), $v, $type] + ($refId ? [3 => $refId] : []);
+	}
+
+
+	private function isSensitive(string $k, $v = null): bool
+	{
+		// data is considered sensitive if the scrubber returns truthy
+		return
+			($this->scrubber !== null && ($this->scrubber)($k, $v)) ||
+			isset($this->keysToHide[strtolower($k)]); // back-compatibility
 	}
 
 

--- a/src/Tracy/Dumper/Dumper.php
+++ b/src/Tracy/Dumper/Dumper.php
@@ -31,6 +31,7 @@ class Dumper
 		LIVE = 'live', // use static $liveSnapshot (used by Bar)
 		SNAPSHOT = 'snapshot', // array used for shared snapshot for lazy-loading via JavaScript
 		DEBUGINFO = 'debuginfo', // use magic method __debugInfo if exists (defaults to false)
+		SCRUBBER = 'scrubber', // detects sensitive keys not to be displayed
 		KEYS_TO_HIDE = 'keystohide', // sensitive keys not displayed (defaults to [])
 		THEME = 'theme'; // color theme (defaults to light)
 
@@ -93,6 +94,9 @@ class Dumper
 	/** @var bool display location by dump()? */
 	public static $showLocation;
 
+	/** @var callable|null  detects sensitive keys not to be displayed by dump() */
+	public static $scrubber = null;
+
 	/** @var array  sensitive keys not displayed by dump() */
 	public static $keysToHide = [];
 
@@ -150,6 +154,7 @@ class Dumper
 			self::ITEMS => self::$maxItems,
 			self::LOCATION => Debugger::$showLocation ?? self::$showLocation,
 			self::KEYS_TO_HIDE => self::$keysToHide,
+			self::SCRUBBER => self::$scrubber,
 			self::THEME => self::$theme,
 		];
 	}
@@ -218,6 +223,7 @@ class Dumper
 		$describer->maxLength = $options[self::TRUNCATE] ?? $describer->maxLength;
 		$describer->maxItems = $options[self::ITEMS] ?? $describer->maxItems;
 		$describer->debugInfo = $options[self::DEBUGINFO] ?? $describer->debugInfo;
+		$describer->scrubber = $options[self::SCRUBBER] ?? $describer->scrubber;
 		$describer->keysToHide = array_flip(array_map('strtolower', $options[self::KEYS_TO_HIDE] ?? []));
 		$describer->resourceExposers = ($options['resourceExporters'] ?? []) + self::$resources;
 		$describer->objectExposers = ($options[self::OBJECT_EXPORTERS] ?? []) + self::$objectExporters;

--- a/tests/Tracy/BlueScreen.getDumper().phpt
+++ b/tests/Tracy/BlueScreen.getDumper().phpt
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('dumper with default scrubbing', function () {
+	$blueScreen = new Tracy\BlueScreen;
+	$dumper = $blueScreen->getDumper();
+	Assert::contains('foo', $dumper('foo', 'bar'));
+	Assert::notContains('secret', $dumper('secret', 'password'));
+	Assert::notContains('secret', $dumper('secret', 'PiN'));
+});
+
+test('dumper with custom scrubbing', function () {
+	$blueScreen = new Tracy\BlueScreen;
+	$blueScreen->scrubber = function (string $k, $v = null): bool {
+		return strtolower($k) === 'pin' || strtolower($k) === 'foo' || $v === 42;
+	};
+	$dumper = $blueScreen->getDumper();
+	Assert::contains('foo', $dumper('foo', 'bar'));
+	Assert::contains('secret', $dumper('secret', 'password'));
+
+	Assert::notContains('secret', $dumper('secret', 'PiN')); // scrubbed by key
+	Assert::notContains('42', $dumper(42, 'bar')); // scrubbed by value
+});
+
+test('dumper with regexp scrubbing', function () {
+	$blueScreen = new Tracy\BlueScreen;
+	$blueScreen->scrubber = function (string $k): bool {
+		return (bool) preg_match('#password#i', $k);
+	};
+	$dumper = $blueScreen->getDumper();
+	Assert::contains('foo', $dumper('foo', 'bar'));
+	Assert::notContains('secret', $dumper('secret', 'super_password'));
+
+	$fix = [
+		'password' => 'secret',
+		'pin' => 'pinok',
+		'password_check' => 'secret',
+		'DATABASE_PASSWORD' => 'secret',
+	];
+	Assert::notContains('secret', $dumper($fix));
+	Assert::contains('pinok', $dumper($fix));
+});

--- a/tests/Tracy/Dumper.scrubber.phpt
+++ b/tests/Tracy/Dumper.scrubber.phpt
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+use Tracy\Dumper;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$obj = (object) [
+	'a' => 456,
+	'password' => 'secret1',
+	'PASSWORD' => 'secret2',
+	'Pin' => 'secret3',
+	'foo' => 'bar',
+	'q' => 42,
+	'inner' => [
+		'a' => 123,
+		'password' => 'secret4',
+		'PASSWORD' => 'secret5',
+		'Pin' => 'secret6',
+		'bar' => 42,
+	],
+];
+$scrubber = function (string $k, $v = null): bool {
+	return strtolower($k) === 'pin' || strtolower($k) === 'foo' || $v === 42;
+};
+$expect1 = <<<'XX'
+stdClass #%d%
+   a: 456
+   password: 'secret1'
+   PASSWORD: 'secret2'
+   Pin: ***** (string)
+   foo: ***** (string)
+   q: ***** (integer)
+   inner: array (5)
+   |  'a' => 123
+   |  'password' => 'secret4'
+   |  'PASSWORD' => 'secret5'
+   |  'Pin' => ***** (string)
+   |  'bar' => ***** (integer)
+XX;
+
+Assert::match($expect1, Dumper::toText($obj, [Dumper::SCRUBBER => $scrubber]));
+
+// scrubber works with "keys to hide" (back compatibility)
+$expect2 = <<<'XX'
+stdClass #%d%
+   a: 456
+   password: ***** (string)
+   PASSWORD: ***** (string)
+   Pin: ***** (string)
+   foo: ***** (string)
+   q: ***** (integer)
+   inner: array (5)
+   |  'a' => 123
+   |  'password' => ***** (string)
+   |  'PASSWORD' => ***** (string)
+   |  'Pin' => ***** (string)
+   |  'bar' => ***** (integer)
+XX;
+Assert::match($expect2, Dumper::toText($obj, [Dumper::SCRUBBER => $scrubber, Dumper::KEYS_TO_HIDE => ['password']]));


### PR DESCRIPTION
This feature adds possibility to define/configure a custom "scrubber" in a flexible way.
A scrubber allows for custom variable filtering to prevent sensitive data leak.
It expands the currently built-in "keys to hide" scrubbing mechanism, and should IMHO replace it by next major release.

This allows for (among others):
- scrubbing based on value and/or keys (current scrubbing only works with keys)
- scrubbing based on regexp matching (current scubbing only matches exact match, case-insensitive)


```php
Tracy\Debugger::getBlueScreen()->scrubber = function(string $key, $val = null): bool {
    return
        # matches `password`, `password_repeat`, `check_password`, `DATABASE_PASSWORD`, ....
        preg_match('#password#i', $key) ||
        # matches DSN defined connections for services etc.
        ( is_string($val) && preg_match('#^https://#i', $val) )
    ;
}
```
... and any logic users want to _easily_ fit into it.

> Backwards compatibile.

Closes #431 