### PR TITLE
[bugfix] Bar: fix clickable link in sortable tables

### DIFF
--- a/src/Tracy/Bar/panels/errors.panel.phtml
+++ b/src/Tracy/Bar/panels/errors.panel.phtml
@@ -16,6 +16,7 @@ namespace Tracy;
 
 <div class="tracy-inner">
 <table class="tracy-sortable">
+<tr><th>Count</th><th>Error</th></tr>
 <?php foreach ($data as $item => $count): list($file, $line, $message) = explode('|', $item, 3) ?>
 <tr>
 	<td class="tracy-right"><?= $count ? "$count\xC3\x97" : '' ?></td>


### PR DESCRIPTION
- bug fix
- BC break: no
- Target version: `v2.7` because it's bug

Currently is unable to open `editor:` link in Tracy error panel, because the TracySort handler is catching that click.

![image](https://user-images.githubusercontent.com/1657322/101691997-d4beff80-3a6f-11eb-8f56-9cdd17f8481d.png)

This PR is adding table header for Error panel to prevent conflict links in content with sorting feature.

![image](https://user-images.githubusercontent.com/1657322/101692459-8a8a4e00-3a70-11eb-8ae7-fa47cea7cc0f.png)

### Note:
Project contains more sortable tables, only error panel contains anchors and sorting feature together.