### PR TITLE
Debugger: The value of $maxDepth should be higher in production or CLI mode

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -524,17 +524,25 @@ class Debugger
 	 */
 	public static function dump($var, bool $return = false)
 	{
+		$maxDepth = self::$maxDepth;
+		if (self::$productionMode === true || PHP_SAPI === 'cli') {
+			if ($maxDepth < 3) {
+				$maxDepth = 3;
+			} elseif ($maxDepth < 10) {
+				$maxDepth *= 2;
+			}
+		}
 		if ($return) {
-			return Helpers::capture(function () use ($var) {
+			return Helpers::capture(function () use ($var, $maxDepth) {
 				Dumper::dump($var, [
-					Dumper::DEPTH => self::$maxDepth,
+					Dumper::DEPTH => $maxDepth,
 					Dumper::TRUNCATE => self::$maxLength,
 				]);
 			});
 
 		} elseif (!self::$productionMode) {
 			Dumper::dump($var, [
-				Dumper::DEPTH => self::$maxDepth,
+				Dumper::DEPTH => $maxDepth,
 				Dumper::TRUNCATE => self::$maxLength,
 				Dumper::LOCATION => self::$showLocation,
 				Dumper::THEME => self::$dumpTheme,


### PR DESCRIPTION
- new feature
- BC break? yes

In production mode, we do not have the option to increment the value of $maxDepth, which can lose important information (such as the internal state of services and databases) when saving objects to the log.

Wow, GitHub now supports videos:

https://user-images.githubusercontent.com/4738758/102800514-45d9ad80-43b4-11eb-8f0b-f4ffb43e5c64.mov
