### PR TITLE
Debugger::$maxDepth changed to 7

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -62,7 +62,7 @@ class Debugger
 	/********************* Debugger::dump() ****************d*g**/
 
 	/** @var int  how many nested levels of array/object properties display by dump() */
-	public static $maxDepth = 3;
+	public static $maxDepth = 7;
 
 	/** @var int  how long strings display by dump() */
 	public static $maxLength = 150;


### PR DESCRIPTION
- bug fix   <!-- #issue numbers, if any -->
- BC break? no

The value `7` is mentioned in release notes of [2.8.0](https://github.com/nette/tracy/releases/tag/v2.8.0) and in [README](https://github.com/nette/tracy#variable-dumping)