### PR TITLE
open-editor.js: added Visual Studio Code/VS Codium

### DIFF
--- a/tools/open-in-editor/windows/open-editor.js
+++ b/tools/open-in-editor/windows/open-editor.js
@@ -25,6 +25,9 @@ var settings = {
 	// Sublime Text 2
 	// editor: '"C:\\Program Files\\Sublime Text 2\\sublime_text.exe" "%file%:%line%"',
 
+	// Visual Studio Code / VSCodium
+	// editor: '"C:\\Program Files\\Microsoft VS Code\\Code.exe" "--goto" "%file%:%line%"',
+	
 	mappings: {
 		// '/remotepath': '/localpath'
 	}


### PR DESCRIPTION
Extended open-editor.js with Visual Studio Code/VS Codium example.