### PR TITLE
Debugger::enable(): Fix broken autoload [bug]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,14 @@ If you are meeting Tracy for the first time, believe me, your life starts to be 
 Documentation can be found on the [website](https://tracy.nette.org).
 
 
-Support Project
----------------
+[Support Tracy](https://github.com/sponsors/dg)
+-----------------------------------------------
 
 Do you like Tracy? Are you looking forward to the new features?
 
-[![Donate](https://files.nette.org/icons/donation-1.svg?)](https://nette.org/make-donation?to=tracy)
+[![Buy me a coffee](https://files.nette.org/icons/donation-3.svg)](https://github.com/sponsors/dg)
+
+Thank you!
 
 
 Installation and requirements

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -209,7 +209,12 @@ class Debugger
 		set_error_handler([self::class, 'errorHandler']);
 
 		foreach (['Bar/Bar', 'Bar/DefaultBarPanel', 'BlueScreen/BlueScreen', 'Dumper/Dumper', 'Logger/Logger', 'Helpers'] as $path) {
-			require_once dirname(__DIR__) . "/$path.php";
+			$filePath = dirname(__DIR__) . '/' . $path . '.php';
+			if (is_file($filePath)) {
+				require_once $filePath;
+			} else {
+				trigger_error('File "' . $path . '" on path "' . $filePath . '" does not exist.');
+			}
 		}
 
 		self::dispatch();


### PR DESCRIPTION
- bug fix
- BC break? no

While installing Nette Sandbox in Docker, I noticed that in some cases autoload may not be available and classes may not load correctly.

The original implementation goes through an array of strings, but they are not used anywhere and only loads the Debugger each time:

![Screenshot from 2021-03-01 15-26-48](https://user-images.githubusercontent.com/4738758/109511311-31e0b500-7aa3-11eb-9cde-11961cc8407c.png)

The original implementation used a non-existent path (logic error):

![Screenshot from 2021-03-01 15-26-37](https://user-images.githubusercontent.com/4738758/109511396-47ee7580-7aa3-11eb-9e70-3f29a5a5fe5e.png)

Now I have fixed the whole problem.

Thanks.