### PR TITLE
Bluescreen: Add selection color

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,14 @@ If you are meeting Tracy for the first time, believe me, your life starts to be 
 Documentation can be found on the [website](https://tracy.nette.org).
 
 
-Support Project
----------------
+[Support Tracy](https://github.com/sponsors/dg)
+-----------------------------------------------
 
 Do you like Tracy? Are you looking forward to the new features?
 
-[![Donate](https://files.nette.org/icons/donation-1.svg?)](https://nette.org/make-donation?to=tracy)
+[![Buy me a coffee](https://files.nette.org/icons/donation-3.svg)](https://github.com/sponsors/dg)
+
+Thank you!
 
 
 Installation and requirements

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -60,6 +60,11 @@
 	font-size: 13pt;
 }
 
+#tracy-bs-error::selection, #tracy-bs-error ::selection {
+	color: black !important;
+	background: #FDF5CE !important;
+}
+
 #tracy-bs-error a {
 	color: #ffefa1 !important;
 }


### PR DESCRIPTION
- new feature
- BC break? no

Hello,

on some systems (like Ubuntu) the user may have a red color to selection the text.

This fix sets the default color for the selection to always the same yellow (according to the code background) and the text as black.

Original example:

![Screenshot from 2021-03-04 14-59-55](https://user-images.githubusercontent.com/4738758/109975916-75cdf700-7cfb-11eb-9ab5-ad734abc79ad.png)

New example:

![Screenshot from 2021-03-04 15-05-25](https://user-images.githubusercontent.com/4738758/109975929-78c8e780-7cfb-11eb-8b62-de6996097736.png)

Thanks.