### PR TITLE
Logger: also drop 'object' before serialization

### DIFF
--- a/src/Tracy/Logger/Logger.php
+++ b/src/Tracy/Logger/Logger.php
@@ -124,7 +124,7 @@ class Logger implements ILogger
 		while ($exception) {
 			$data[] = [
 				get_class($exception), $exception->getMessage(), $exception->getCode(), $exception->getFile(), $exception->getLine(),
-				array_map(function (array $item): array { unset($item['args']); return $item; }, $exception->getTrace()),
+				array_map(function (array $item): array { unset($item['args'], $item['object']); return $item; }, $exception->getTrace()),
 			];
 			$exception = $exception->getPrevious();
 		}


### PR DESCRIPTION
- bug fix
- no BC break

When stack trace contains `'object'` field (which is awesomely supported for many years :) ), `Logger` doesn't get rid of it before serialization when establishing exception file name. This PR removes the `'object'` field in same way as `'args'` is being dropped already.