### PR TITLE
Debugger: shows error message in console

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -319,8 +319,12 @@ class Debugger
 					require self::$errorTemplate ?: __DIR__ . '/assets/error.500.phtml';
 				})(empty($e));
 			} elseif (PHP_SAPI === 'cli') {
-				@fwrite(STDERR, 'ERROR: application encountered an error and can not continue. '
-					. (isset($e) ? "Unable to log error.\n" : "Error was logged.\n")); // @ triggers E_NOTICE when strerr is closed since PHP 7.4
+				// @ triggers E_NOTICE when strerr is closed since PHP 7.4
+				@fwrite(STDERR, "ERROR: {$exception->getMessage()}\n"
+					. (isset($e)
+						? 'Unable to log error. You may try enable debug mode to inspect the problem.'
+						: 'Check log to see more info.')
+					. "\n");
 			}
 
 		} elseif ($firstTime && Helpers::isHtmlMode() || Helpers::isAjax()) {


### PR DESCRIPTION
I just don't think there is a reason to not show error message in console. But I may be wrong, let me know if I missed something.
