### PR TITLE
Debugger: Add property $enableDispatch for disable dispatching.

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -40,6 +40,9 @@ class Debugger
 	public static $reservedMemorySize = 500000;
 
 	/** @var bool */
+	public static $enableDispatch = true;
+
+	/** @var bool */
 	private static $enabled = false;
 
 	/** @var string|null reserved memory; also prevents double rendering */
@@ -219,7 +222,7 @@ class Debugger
 
 	public static function dispatch(): void
 	{
-		if (self::$productionMode || PHP_SAPI === 'cli') {
+		if (!self::$enableDispatch || self::$productionMode || PHP_SAPI === 'cli') {
 			return;
 
 		} elseif (headers_sent($file, $line) || ob_get_length()) {


### PR DESCRIPTION
- bug fix
- BC break? no

In some Tracy integrations outside the Nette framework, we need to ensure that the request is not called twice when downloading assets for Tracy.

Outside of Bootstrap, this behavior is not guaranteed, so there should be an easy way to disable dispatch but also have active debug mode.

Thank you.