### PR TITLE
Enrich tracy error mail with request method

### DIFF
--- a/src/Bridges/Nette/MailSender.php
+++ b/src/Bridges/Nette/MailSender.php
@@ -50,7 +50,7 @@ class MailSender
 			$mail->addTo(trim($item));
 		}
 		$mail->setSubject('PHP: An error occurred on the server ' . $host);
-		$mail->setBody(Tracy\Logger::formatMessage($message) . "\n\nsource: " . Tracy\Helpers::getSource());
+		$mail->setBody(Tracy\Logger::formatMessage($message) . "\n\nsource: " . Tracy\Helpers::getSource() . Tracy\Helpers::formatMethod());
 
 		$this->mailer->send($mail);
 	}

--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -172,6 +172,13 @@ class Helpers
 
 
 	/** @internal */
+        public static function formatMethod(): string
+        {
+                return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] !== 'GET' ? (' [' . $_SERVER['REQUEST_METHOD'] . ']') : '';
+        }
+
+
+	/** @internal */
 	public static function improveException(\Throwable $e): void
 	{
 		$message = $e->getMessage();

--- a/src/Tracy/Logger/Logger.php
+++ b/src/Tracy/Logger/Logger.php
@@ -191,7 +191,7 @@ class Logger implements ILogger
 					'Content-Transfer-Encoding: 8bit',
 				]) . "\n",
 				'subject' => "PHP: An error occurred on the server $host",
-				'body' => static::formatMessage($message) . "\n\nsource: " . Helpers::getSource(),
+				'body' => static::formatMessage($message) . "\n\nsource: " . Helpers::getSource() . Helpers::formatMethod(),
 			]
 		);
 


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs# 2B after approval

When using nette/tracy for API project, having request method in tracy error mail is for us highly valuable information. I simply injected this information right after source url. If the method was GET, nothing gets injected (kinda like default method). Method gets injected only for all other methods