### PR TITLE
typo

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -98,7 +98,7 @@ class Debugger
 
 	/********************* misc ****************d*g**/
 
-	/** @var int timestamp with microseconds of the start of the request */
+	/** @var float timestamp with microseconds of the start of the request */
 	public static $time;
 
 	/** @var string URI pattern mask to open editor */


### PR DESCRIPTION
- bug fix
- BC break? yes

Property `$time` is always `float`. Testing code:

```php
dump([
    $_SERVER['REQUEST_TIME_FLOAT'],
    microtime(true),
    \Tracy\Debugger::$time,
    't'
]);
```

![Screenshot from 2021-06-02 15-46-50](https://user-images.githubusercontent.com/4738758/120491725-c4059b80-c3b9-11eb-91eb-ae0c108b4e64.png)

Thanks.