### PR TITLE
Debugger: render code snipet in CLI on error (#494)(#490)

### DIFF
--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -337,6 +337,44 @@ class BlueScreen
 
 
 	/**
+	 * Returns syntax highlighted source code to Terminal.
+	 */
+	public static function highlightPhpCli(string $file, int $line, int $lines = 15): string
+	{
+		$out = '';
+		if (is_file($file) === true) {
+			$content = (string) file_get_contents($file);
+			$source = explode("\n", str_replace(["\r\n", "\r"], "\n", $content));
+
+			$start = max(1, min($line, count($source) - 1) - (int) floor($lines * 2 / 3));
+			for ($i = $start; $i <= $start + $lines; $i++) {
+				if (isset($source[$i]) === false) {
+					break;
+				}
+
+				$currentLine = $i + 1;
+				if ($line === $currentLine) { // highlight line
+					$windowSize = (int) getenv('COLUMNS');
+					$out .= "\e[1;37m\e[41m" . str_pad(' ' . $currentLine . ': ', 6, ' ');
+					$lineC = str_replace("\t", '    ', (string) preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $source[$i]));
+					if ($windowSize > 10) {
+						$out .= str_pad($lineC, $windowSize > 500 ? 500 : $windowSize - 10, ' ');
+					} else {
+						$out .= $lineC;
+					}
+					$out .= "\e[0m\n";
+				} else {
+					$out .= "\e[100m" . str_pad(' ' . $currentLine . ': ', 6, ' ') . "\e[0m";
+					$out .= str_replace("\t", '    ', $source[$i]);
+					$out .= "\n";
+				}
+			}
+		}
+		return $out;
+	}
+
+
+	/**
 	 * Should a file be collapsed in stack trace?
 	 * @internal
 	 */

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -324,7 +324,7 @@ class Debugger
 					. (isset($e)
 						? 'Unable to log error. You may try enable debug mode to inspect the problem.'
 						: 'Check log to see more info.')
-					. (self::$productionMode
+					. (!self::$productionMode
 						? "\n\n"
 						. $exception->getFile() . ':' . $exception->getLine() . "\n"
 						. BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine())

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -323,7 +323,9 @@ class Debugger
 				@fwrite(STDERR, "ERROR: {$exception->getMessage()}\n"
 					. (isset($e)
 						? 'Unable to log error. You may try enable debug mode to inspect the problem.'
-						: 'Check log to see more info.')
+						: 'Check log to see more info.') . "\n\n"
+					  . $exception->getFile() . ':' . $exception->getLine() . "\n"
+					  . BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine())
 					. "\n");
 			}
 

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -324,12 +324,7 @@ class Debugger
 					. (isset($e)
 						? 'Unable to log error. You may try enable debug mode to inspect the problem.'
 						: 'Check log to see more info.')
-					. (!self::$productionMode
-						? "\n\n"
-						. $exception->getFile() . ':' . $exception->getLine() . "\n"
-						. BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine())
-						: ''
-					) . "\n");
+					. "\n");
 			}
 
 		} elseif ($firstTime && Helpers::isHtmlMode() || Helpers::isAjax()) {
@@ -343,6 +338,11 @@ class Debugger
 					header("X-Tracy-Error-Log: $file", false);
 				}
 				echo "$exception\n" . ($file ? "(stored in $file)\n" : '');
+				if (!self::$productionMode && PHP_SAPI === 'cli') {
+					echo "\n\n"
+						. $exception->getFile() . ':' . $exception->getLine() . "\n"
+						. BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine());
+				}
 				if ($file && self::$browser) {
 					exec(self::$browser . ' ' . escapeshellarg(strtr($file, self::$editorMapping)));
 				}

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -324,8 +324,8 @@ class Debugger
 					. (isset($e)
 						? 'Unable to log error. You may try enable debug mode to inspect the problem.'
 						: 'Check log to see more info.') . "\n\n"
-					  . $exception->getFile() . ':' . $exception->getLine() . "\n"
-					  . BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine())
+						. $exception->getFile() . ':' . $exception->getLine() . "\n"
+						. BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine())
 					. "\n");
 			}
 

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -323,10 +323,13 @@ class Debugger
 				@fwrite(STDERR, "ERROR: {$exception->getMessage()}\n"
 					. (isset($e)
 						? 'Unable to log error. You may try enable debug mode to inspect the problem.'
-						: 'Check log to see more info.') . "\n\n"
+						: 'Check log to see more info.')
+					. (self::$productionMode
+						? "\n\n"
 						. $exception->getFile() . ':' . $exception->getLine() . "\n"
 						. BlueScreen::highlightPhpCli($exception->getFile(), $exception->getLine())
-					. "\n");
+						: ''
+					) . "\n");
 			}
 
 		} elseif ($firstTime && Helpers::isHtmlMode() || Helpers::isAjax()) {


### PR DESCRIPTION
- new feature
- BC break? no

Rel #490

A simple tool for plotting an uncaught exception (or other error) directly to the terminal in CLI mode. It makes it very easy to debug the application on the server.

Real example:

![Screenshot from 2021-06-09 09-24-11](https://user-images.githubusercontent.com/4738758/121311499-c493ba00-c904-11eb-92d1-30eb236435cd.png)

Thanks!