### PR TITLE
Logger: Add current datetime to e-mail log message.

### DIFF
--- a/src/Tracy/Logger/Logger.php
+++ b/src/Tracy/Logger/Logger.php
@@ -191,7 +191,9 @@ class Logger implements ILogger
 					'Content-Transfer-Encoding: 8bit',
 				]) . "\n",
 				'subject' => "PHP: An error occurred on the server $host",
-				'body' => static::formatMessage($message) . "\n\nsource: " . Helpers::getSource(),
+				'body' => static::formatMessage($message)
+					. "\n\nsource: " . Helpers::getSource()
+					. "\n\ndate: " . date('[Y-m-d H-i-s]'),
 			]
 		);
 


### PR DESCRIPTION
- new feature?
- BC break? no

Just adding a datetime to better reveal when the error has occurred.

Sending an email can have a delay, this can reveal the real time the error was caught right in the email.