### PR TITLE
BlueScreen: Render actions can fail.

### DIFF
--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -152,7 +152,11 @@ class BlueScreen
 		$css = Helpers::minifyCss(implode($css));
 
 		$nonce = $toScreen ? Helpers::getNonce() : null;
-		$actions = $toScreen ? $this->renderActions($exception) : [];
+		try {
+			$actions = $toScreen ? $this->renderActions($exception) : [];
+		} catch (\Throwable $e) {
+			$actions = [];
+		}
 
 		require $template;
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

If a fatal autoloader error is thrown, no bluescreen is displayed (or logged) because the `renderActions()` method internally verifies the nonexistence of a class that may recursively fail due to an autoloader.

For example:

![Snímek obrazovky 2021-06-23 v 17 19 32](https://user-images.githubusercontent.com/4738758/123124297-d9fdfd80-d447-11eb-8776-a4d681752f42.png)

In the log you can then (under certain circumstances) see all the way through Tracy:

![Snímek obrazovky 2021-06-23 v 17 20 20](https://user-images.githubusercontent.com/4738758/123124387-eaae7380-d447-11eb-8ab9-939234629578.png)

![Snímek obrazovky 2021-06-23 v 17 21 47](https://user-images.githubusercontent.com/4738758/123125181-95269680-d448-11eb-93ef-ff62a26f7278.png)

It is only when the internal exception throwing is handled that we learn the real error (which has otherwise been discarded):

![Snímek obrazovky 2021-06-23 v 17 21 26](https://user-images.githubusercontent.com/4738758/123124492-0580e800-d448-11eb-94cf-c232f656cd61.png)

Thanks.