### PR TITLE
BlueScreen: used scrubber for HTTP headers

### DIFF
--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -280,7 +280,7 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			<div class="outer">
 			<table>
 			<?php
-			foreach ($_SERVER['argv'] as $k => $v) echo '<tr><th>', Helpers::escapeHtml($k), '</th><td>', Helpers::escapeHtml($v), "</td></tr>\n";
+			foreach ($_SERVER['argv'] as $k => $v) echo '<tr><th>', Helpers::escapeHtml($k), '</th><td>', $dump($v, $k), "</td></tr>\n";
 			?>
 			</table>
 			</div>
@@ -299,7 +299,7 @@ $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 			<div class="outer">
 			<table class="tracy-sortable">
 			<?php
-			foreach ($httpHeaders as $k => $v) echo '<tr><th>', Helpers::escapeHtml($k), '</th><td>', Helpers::escapeHtml($v), "</td></tr>\n";
+			foreach ($httpHeaders as $k => $v) echo '<tr><th>', Helpers::escapeHtml($k), '</th><td>', $dump($v, $k), "</td></tr>\n";
 			?>
 			</table>
 			</div>


### PR DESCRIPTION
Two sections of BlueScreen were previously not properly scrubbed:
- HTTP Reqeust / Headers
- CLI Request / Arguments

This includes, for example, the `Cookie` header, which can easily be used to hijack the session:
![image](https://user-images.githubusercontent.com/443067/125301172-fd231b00-e32a-11eb-8a31-e98d12bf6622.png)

The Cookie is plaintext-legible in the `Headers` section, while the `$_COOKIE` section right below gets properly scrubbed:
![image](https://user-images.githubusercontent.com/443067/125301379-38254e80-e32b-11eb-8806-f512eb4ff238.png)

This PR fixes the issue.

- bug fix
- BC break? no
