### PR TITLE
 Bugfix for bluescreen generated by AJAX

### DIFF
--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -23,6 +23,10 @@ namespace Tracy;
 
 $code = $exception->getCode() ? ' #' . $exception->getCode() : '';
 
+if (!isset($exceptions)) {
+	$exceptions = Helpers::getExceptionChain($exception);
+}
+
 ?>
 <div id="tracy-bs" itemscope>
 	<a id="tracy-bs-toggle" href="#" class="tracy-toggle"></a>


### PR DESCRIPTION
Bluescreen method render() requires content.phtml directly without page.phtml. This is causing undefined variable $exceptions for exceptions in AJAX calls. Bugfix appeared after fixing issue #499.

- bug fix after changes done in #499 
- BC break? no
- doc PR: n/a

Variable $exceptions was not initiated when content.phtml was required directly without page.phtml in case of AJAX calls.