### PR TITLE
Compatibility with psr/log ^2.0 and ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"nette/mail": "^3.0",
 		"nette/tester": "^2.2",
 		"latte/latte": "^2.5",
-		"psr/log": "^1.0",
+		"psr/log": "^1.0|^2.0|^3.0",
 		"phpstan/phpstan": "^0.12"
 	},
 	"conflict": {

--- a/src/Bridges/Psr/TracyToPsrLoggerAdapter.php
+++ b/src/Bridges/Psr/TracyToPsrLoggerAdapter.php
@@ -40,7 +40,7 @@ class TracyToPsrLoggerAdapter extends Psr\Log\AbstractLogger
 	}
 
 
-	public function log($level, $message, array $context = [])
+	public function log($level, $message, array $context = []): void
 	{
 		$level = self::LEVEL_MAP[$level] ?? Tracy\ILogger::ERROR;
 

--- a/tests/Tracy.Bridges/PsrToTracyLoggerAdapter.phpt
+++ b/tests/Tracy.Bridges/PsrToTracyLoggerAdapter.phpt
@@ -19,7 +19,7 @@ class DummyPsrLogger extends Psr\Log\AbstractLogger
 	public $entries = [];
 
 
-	public function log($level, $message, array $context = [])
+	public function log($level, $message, array $context = []): void
 	{
 		$this->entries[] = [$level, $message, $context];
 	}


### PR DESCRIPTION
- new feature
- BC break? yes
- doc PR: not needed?

Minimum needed to be compatible with psr/log ^3.0. It should be safe to do on PHP >=7.2, any extending class just have to add return type too.