### PR TITLE
Bluescreen: scrub used for HTTP Response headers

### DIFF
--- a/src/Tracy/BlueScreen/assets/content.phtml
+++ b/src/Tracy/BlueScreen/assets/content.phtml
@@ -331,7 +331,7 @@ $exceptions = $exceptions ?? Helpers::getExceptionChain($exception);
 			<div class="outer">
 			<table class="tracy-sortable">
 			<?php
-			foreach (headers_list() as $s) { $s = explode(':', $s, 2); echo '<tr><th>', Helpers::escapeHtml($s[0]), '</th><td>', Helpers::escapeHtml(trim($s[1])), "</td></tr>\n"; }
+			foreach (headers_list() as $s) { $s = explode(':', $s, 2); echo '<tr><th>', Helpers::escapeHtml($s[0]), '</th><td>', $dump(trim($s[1]), trim($s[0])), "</td></tr>\n"; }
 			?>
 			</table>
 			</div>


### PR DESCRIPTION
- bug fix, potential sensitive info leak
- BC break? no

Same issue as #498, but for **Response** headers this time...

This may also cause the same security issue (session hijack) with `Set-Cookie` response header.

With proper scrubber (#439) setting the leak can be mitigated.