### PR TITLE
Allow to select error severity for Debugger::$scream

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -56,7 +56,7 @@ class Debugger
 	/** @var bool|int determines whether any error will cause immediate death in development mode; if integer that it's matched against error severity */
 	public static $strictMode = false;
 
-	/** @var bool disables the @ (shut-up) operator so that notices and warnings are no longer hidden */
+	/** @var bool|int disables the @ (shut-up) operator so that notices and warnings are no longer hidden; if integer than it's matched against error severity */
 	public static $scream = false;
 
 	/** @var callable[] functions that are automatically called after fatal error */
@@ -401,7 +401,7 @@ class Debugger
 		}
 
 		if (self::$scream) {
-			error_reporting(E_ALL);
+			error_reporting(self::$scream === true ? E_ALL : (self::$scream | error_reporting()));
 		}
 
 		if ($context) {

--- a/tests/Tracy.Bridges/TracyExtension.services.phpt
+++ b/tests/Tracy.Bridges/TracyExtension.services.phpt
@@ -23,7 +23,9 @@ $compiler->setClassName('Container');
 $compiler->addExtension('tracy', new TracyExtension);
 $compiler->addConfig([
 	'tracy' => [
-		'logSeverity' => 'E_USER_WARNING',
+		'logSeverity' => ['E_USER_WARNING', E_USER_NOTICE],
+		'strictMode' => 'E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED',
+		'scream' => 'E_DEPRECATED | E_USER_DEPRECATED',
 		'keysToHide' => ['abc'],
 	],
 	'services' => [
@@ -46,6 +48,8 @@ Assert::same(Tracy\Debugger::getLogger(), $container->getService('tracy.logger')
 Assert::same(Tracy\Debugger::getBlueScreen(), $container->getService('tracy.blueScreen'));
 Assert::same(Tracy\Debugger::getBar(), $container->getService('tracy.bar'));
 
-Assert::same(E_USER_WARNING, Tracy\Debugger::$logSeverity);
+Assert::same(E_USER_WARNING | E_USER_NOTICE, Tracy\Debugger::$logSeverity);
+Assert::same(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED, Tracy\Debugger::$strictMode);
+Assert::same(E_DEPRECATED | E_USER_DEPRECATED, Tracy\Debugger::$scream);
 Assert::contains('password', Tracy\Debugger::getBlueScreen()->keysToHide);
 Assert::contains('abc', Tracy\Debugger::getBlueScreen()->keysToHide);

--- a/tests/Tracy/Debugger.scream.E_USER_DEPRECATED.phpt
+++ b/tests/Tracy/Debugger.scream.E_USER_DEPRECATED.phpt
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test: Tracy\Debugger scream mode with specified severity.
+ * @outputMatchFile expected/Debugger.scream.E_USER_DEPRECATED.expect
+ */
+
+declare(strict_types=1);
+
+use Tracy\Debugger;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Debugger::$productionMode = false;
+Debugger::$scream = E_USER_DEPRECATED;
+header('Content-Type: text/plain; charset=utf-8');
+
+Debugger::enable();
+
+trigger_error('E_USER_WARNING that should be reported', E_USER_WARNING);
+@trigger_error('Muted E_USER_WARNING that should be ignored', E_USER_WARNING);
+
+@trigger_error('Muted E_USER_DEPRECATED that should be reported', E_USER_DEPRECATED);

--- a/tests/Tracy/expected/Debugger.scream.E_USER_DEPRECATED.expect
+++ b/tests/Tracy/expected/Debugger.scream.E_USER_DEPRECATED.expect
@@ -1,0 +1,4 @@
+
+Warning: E_USER_WARNING that should be reported in %a% on line %d%
+
+Deprecated: Muted E_USER_DEPRECATED that should be reported in %a% on line %d%


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: TBA if accepted

`Debugger::$scream` is currently simple on/off switch that unmutes all/none of the suppressed errors. This PR adds support for selecting which error severities should be unmuted.

This feature might be useful e.g. for tracking and logging of deprecation errors triggered in "muted" state by some of the popular libraries, see:
- https://github.com/doctrine/deprecations/blob/master/lib/Doctrine/Deprecations/Deprecation.php#L189
- https://github.com/symfony/deprecation-contracts/blob/main/function.php#L25

Setting `Debugger::$scream = E_USER_DEPRECATED` would cause all the deprecations to be tracked by Tracy, while still ignoring all other muted error types.

Second commit adds/improves the support for error severity configuration in `scream`, `strictMode`, `logSeverity` options of `TracyExtension`.