### PR TITLE
[2.5] Fix compatibility with PHP 8.1

### DIFF
--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -44,7 +44,7 @@ class Helpers
 	 * Returns link to editor.
 	 * @return string|null
 	 */
-	public static function editorUri($file, $line = null, $action = 'open', $search = null, $replace = null)
+	public static function editorUri($file, $line = null, $action = 'open', $search = '', $replace = '')
 	{
 		if (Debugger::$editor && $file && ($action === 'create' || is_file($file))) {
 			$file = strtr($file, '/', DIRECTORY_SEPARATOR);


### PR DESCRIPTION
- bug fix
- BC break? no

Fixes a warning on PHP 8.1 (want to start using Tracy for [selfoss](https://github.com/fossar/selfoss), which still supports PHP 5.6).