### PR TITLE
Debugger::timer: switch from microtime to hrtime

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -504,10 +504,10 @@ class Debugger
 	public static function timer(?string $name = null): float
 	{
 		static $time = [];
-		$now = microtime(true);
+		$now = hrtime(true);
 		$delta = isset($time[$name]) ? $now - $time[$name] : 0;
 		$time[$name] = $now;
-		return $delta;
+		return $delta/1e+9;
 	}
 
 


### PR DESCRIPTION
hrtime is faster on virtual machines, due microtime use system call that need to change context from user to kernel (PHP7.3+)

- bug fix / new feature?   optimalization
- BC break? no
- doc PR: nette/docs#???  not needed

<!--
On VMs running on KVM, XEN (openstack, AWS EC2, etc) platforms which lack vDSO the common method of using time() or microtime() can dramatically increase CPU/execution time due to the context switching from userland to kernel when running the `gettimeofday()` system call.
-->
