### PR TITLE
#528 check real path for session storage

### DIFF
--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -449,9 +449,9 @@ class Debugger
 	public static function getSessionStorage(): SessionStorage
 	{
 		if (empty(self::$sessionStorage)) {
-			self::$sessionStorage = @is_dir($dir = session_save_path())
-				|| @is_dir($dir = ini_get('upload_tmp_dir'))
-				|| @is_dir($dir = sys_get_temp_dir())
+			self::$sessionStorage = (realpath(session_save_path()) && @is_dir($dir = session_save_path()))
+				|| (realpath(ini_get('upload_tmp_dir')) && @is_dir($dir = ini_get('upload_tmp_dir')))
+				|| (realpath(sys_get_temp_dir()) && @is_dir($dir = sys_get_temp_dir()))
 				|| ($dir = self::$logDirectory)
 				? new FileSession($dir)
 				: new NativeSession;


### PR DESCRIPTION
- bug fix / new feature?   fix #528
- BC break? no (shouldn't)

Checking session location via is_dir results in an error should the storage not be on local disk (files), eg: when using redis. Using @ may silence the error but this doesn't work when there's a customer error handle involved.

However using realpath will guard against cases when the location is not a real path on local storage. 
