### PR TITLE
psr3 adapter for monolog/monolog example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,29 @@ If you use the Nette Framework, you can set this and others in the configuration
 To protect your e-mail box from flood, Tracy sends **only one message** and creates a file `email-sent`. When a developer receives the e-mail notification, he checks the log, corrects his application and deletes the `email-sent` monitoring file. This activates the e-mail sending again.
 
 
+### Using the PSR-3 Adapter
+This package provides a PSR-3 adapter, allowing for integration of [monolog/monolog](https://github.com/Seldaek/monolog).
+
+```php
+use Tracy\ILogger;
+use Tracy\Debugger;
+use Tracy\Bridges\Psr\PsrToTracyLoggerAdapter;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+require_once "vendor/autoload.php";
+
+$monolog = new Logger('main-channel');
+$monolog->pushHandler(new StreamHandler($logfile_path, Logger::DEBUG));
+
+$tracyLogger = new PsrToTracyLoggerAdapter($monolog);
+Debugger::setLogger($tracyLogger);
+Debugger::enable();
+
+Debugger::log("info"); // writes: [<TIMESTAMP>] main-channel.INFO: info [] []
+Debugger::log('warning', ILogger::WARNING); // writes: [<TIMESTAMP>] main-channel.WARNING: warning [] []
+```
+
 Variable dumping
 ----------------
 


### PR DESCRIPTION
I tested with the following code:

index.php
```php
<?PHP
use Tracy\ILogger;
use Tracy\Debugger;
use Tracy\Bridges\Psr\PsrToTracyLoggerAdapter;
use Monolog\Logger;
use Monolog\Handler\StreamHandler;

require_once "vendor/autoload.php";

$monolog = new Logger('main-channel');
$monolog->pushHandler(new StreamHandler("/private/tmp/ok/lol.log", Logger::DEBUG));

$tracyLogger = new PsrToTracyLoggerAdapter($monolog);
Debugger::setLogger($tracyLogger);
Debugger::enable();

Debugger::log("info");
Debugger::log('warning', ILogger::WARNING);
```

composer.json
```php
{
    "name": "paxperscientiam/ok",
    "require-dev": {
        "tracy/tracy": "^2.9",
        "monolog/monolog": "^2.3"
    },
    "autoload": {
        "psr-4": {
            "Paxperscientiam\\Ok\\": "src/"
        }
    },
    "authors": [
        {
            "name": "Chris",
            "email": "7539871+paxperscientiam@users.noreply.github.com"
        }
    ],
    "require": {}
}
```

- bug fix / new feature?   <!-- #issue numbers, if any -->
- BC break? yes/no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
