### PR TITLE
Unlock session file before close

### DIFF
--- a/src/Tracy/Session/FileSession.php
+++ b/src/Tracy/Session/FileSession.php
@@ -98,6 +98,7 @@ class FileSession implements SessionStorage
 		ftruncate($this->file, 0);
 		fseek($this->file, 0);
 		fwrite($this->file, serialize($this->data));
+		flock($this->file, LOCK_UN);
 		fclose($this->file);
 		$this->file = null;
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

There is a problem with locking when you use php to execute  bash script with background processes eg. https://stackoverflow.com/questions/71929617/php-8-1-not-release-flock-after-calling-exec

Unlocking before fclose seems to be a solution.
