### PR TITLE
Sort with natural sort instead.

### DIFF
--- a/src/Tracy/assets/table-sort.js
+++ b/src/Tracy/assets/table-sort.js
@@ -27,7 +27,7 @@ class TableSort
 			.slice(preserveFirst ? 1 : 0)
 			.sort((a, b) => {
 				return function(v1, v2) {
-					return v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2);
+					return v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2, undefined, { numeric: true, sensitivity: 'base' });
 				}(getText((asc ? a : b).children[tcell.cellIndex]), getText((asc ? b : a).children[tcell.cellIndex]));
 			})
 			.forEach((tr) => { tbody.appendChild(tr); });


### PR DESCRIPTION
We noticed when using the table sort that it would sort things alphabetically instead of numerically (if the field happened to start with a number). This fixes it while maintaining alphabetical sorting.

- Improvement: Table sorting
- BC break? no
- doc PR: It's an internal fix that doesn't need to be documented

The problem we were running into is that we would have errors in our project sort like the following:
- 1x
- 1x
- 145x
- 2x
- 201x
- 3x
- 4x
- etc.

It is the same for measuring database query times, etc. Anything numeric with text in it, it would kinda choke. Adding these couple extra arguments to the localeCompare() function allows it to sort numerics properly while maintaining alphabetical sorting.

BTW, looked for unit tests for your js stuff, but didn't find anything :grimacing: 