### PR TITLE
TracyExtension: set mailer to logger service instead of staticly get logger

### DIFF
--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -120,7 +120,7 @@ class TracyExtension extends Nette\DI\CompilerExtension
 		}
 
 		if ($this->config->netteMailer && $builder->getByType(Nette\Mail\IMailer::class)) {
-			$initialize->addBody($builder->formatPhp('Tracy\Debugger::getLogger()->mailer = ?;', [
+			$initialize->addBody($builder->formatPhp('if (($logger = Tracy\Debugger::getLogger()) instanceof Tracy\Logger) $logger->mailer = ?;', [
 				[new Nette\DI\Statement(Tracy\Bridges\Nette\MailSender::class, ['fromEmail' => $this->config->fromEmail]), 'send'],
 			]));
 		}

--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -120,7 +120,8 @@ class TracyExtension extends Nette\DI\CompilerExtension
 		}
 
 		if ($this->config->netteMailer && $builder->getByType(Nette\Mail\IMailer::class)) {
-			$initialize->addBody($builder->formatPhp('if (($logger = Tracy\Debugger::getLogger()) instanceof Tracy\Logger) $logger->mailer = ?;', [
+			$initialize->addBody($builder->formatPhp('if (($logger = ?) instanceof Tracy\Logger) $logger->mailer = ?;', [
+				$logger,
 				[new Nette\DI\Statement(Tracy\Bridges\Nette\MailSender::class, ['fromEmail' => $this->config->fromEmail]), 'send'],
 			]));
 		}

--- a/src/Tracy/Bar/assets/bar.css
+++ b/src/Tracy/Bar/assets/bar.css
@@ -72,6 +72,11 @@ body#tracy-debug { /* in popup window */
 	display: inline;
 }
 
+#tracy-debug .tracy-dump {
+	margin: 0;
+	padding: 2px 5px;
+}
+
 
 /* bar */
 #tracy-debug-bar {


### PR DESCRIPTION
- bug fix 
- BC break? hard to tell

Commit https://github.com/nette/tracy/commit/0b615627e1229d33abc016620c8239ebcb20654f introduces condition that breaks my logger. It connects Monolog and Tracy logger in a way it is possible to log from Tracy to Monolog and from Monolog to Tracy while maintaining configuration of these loggers.

Since condition was introduced, replacing Tracy\Logger causes `mailer` option to be ignored *if Monolog extension is loaded firsts*. Because at point where mailer is set, `Tracy\Debugger::getLogger()` already returns different instance.

![broken](https://user-images.githubusercontent.com/20974277/210458752-a9a46048-ad20-461b-ae01-05b6eb608806.PNG)

By changing `Tracy\Debugger::getLogger()` to `$this->getService('tracy.logger')` I can maintain logger compatibility, while keeping fix for #549.

![fixed](https://user-images.githubusercontent.com/20974277/210459113-c08bdc9c-8ca3-4984-98db-725bd460a9f5.PNG)

Note: These options probably have the same problem as described in #549.
https://github.com/nette/tracy/blob/0b615627e1229d33abc016620c8239ebcb20654f/src/Bridges/Nette/TracyExtension.php#L104-L105

If we change these calls from static getLogger() to getService() we may as well check if service `tracy.logger` will create `Tracy\Logger` and if not and one of these options is set, warn user about incompatible logger. Because current condition fix is just ignoring incompatible options which should not be set, if logger does not support them.

Sorry for long description, it was just crazy complex to make loggers work perfectly fine together and I don't have any other way of fixing it.
