### PR TITLE
Server name from nette/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
 		"nette/tester": "^2.2",
 		"latte/latte": "^2.5",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
-		"phpstan/phpstan": "^1.0"
+		"phpstan/phpstan": "^1.0",
+		"nette/http": "^3.0"
 	},
 	"conflict": {
 		"nette/di": "<3.0"

--- a/src/Bridges/Nette/MailSender.php
+++ b/src/Bridges/Nette/MailSender.php
@@ -21,21 +21,23 @@ class MailSender
 	use Nette\SmartObject;
 
 	private Nette\Mail\IMailer $mailer;
+    private ?Nette\Http\Request $request;
 
 	/** @var string|null sender of email notifications */
 	private ?string $fromEmail = null;
 
 
-	public function __construct(Nette\Mail\IMailer $mailer, ?string $fromEmail = null)
+	public function __construct(Nette\Mail\IMailer $mailer, ?string $fromEmail = null, ?Nette\Http\Request $request = null)
 	{
 		$this->mailer = $mailer;
 		$this->fromEmail = $fromEmail;
+        $this->request = $request;
 	}
 
 
 	public function send(mixed $message, string $email): void
 	{
-		$host = preg_replace('#[^\w.-]+#', '', $_SERVER['SERVER_NAME'] ?? php_uname('n'));
+		$host = preg_replace('#[^\w.-]+#', '', $this->getHost());
 
 		$mail = new Nette\Mail\Message;
 		$mail->setHeader('X-Mailer', 'Tracy');
@@ -52,4 +54,12 @@ class MailSender
 
 		$this->mailer->send($mail);
 	}
+
+    private function getHost(): string
+    {
+        if ($this->request !== null) {
+            return $this->request->getUrl()->getHost();
+        }
+        return $_SERVER['SERVER_NAME'] ?? php_uname('n');
+    }
 }

--- a/src/Bridges/Nette/MailSender.php
+++ b/src/Bridges/Nette/MailSender.php
@@ -21,7 +21,7 @@ class MailSender
 	use Nette\SmartObject;
 
 	private Nette\Mail\IMailer $mailer;
-    private ?Nette\Http\Request $request;
+	private ?Nette\Http\Request $request;
 
 	/** @var string|null sender of email notifications */
 	private ?string $fromEmail = null;
@@ -55,11 +55,11 @@ class MailSender
 		$this->mailer->send($mail);
 	}
 
-    private function getHost(): string
+	private function getHost(): string
     {
-        if ($this->request !== null) {
-            return $this->request->getUrl()->getHost();
-        }
-        return $_SERVER['SERVER_NAME'] ?? php_uname('n');
-    }
+		if ($this->request !== null) {
+			return $this->request->getUrl()->getHost();
+		}
+		return $_SERVER['SERVER_NAME'] ?? php_uname('n');
+	}
 }

--- a/src/Bridges/Nette/MailSender.php
+++ b/src/Bridges/Nette/MailSender.php
@@ -23,6 +23,7 @@ class MailSender
 
 	/** @var string|null sender of email notifications */
 	private ?string $fromEmail = null;
+
 	/** @var string|null actual host on which notification occurred - visible in subject */
 	private ?string $host = null;
 

--- a/src/Bridges/Nette/MailSender.php
+++ b/src/Bridges/Nette/MailSender.php
@@ -31,7 +31,7 @@ class MailSender
 	{
 		$this->mailer = $mailer;
 		$this->fromEmail = $fromEmail;
-        $this->request = $request;
+		$this->request = $request;
 	}
 
 
@@ -56,7 +56,7 @@ class MailSender
 	}
 
 	private function getHost(): string
-    {
+	{
 		if ($this->request !== null) {
 			return $this->request->getUrl()->getHost();
 		}

--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -116,8 +116,14 @@ class TracyExtension extends Nette\DI\CompilerExtension
 		}
 
 		if ($this->config->netteMailer && $builder->getByType(Nette\Mail\IMailer::class)) {
+			$senderParams = [];
+			$senderParams['fromEmail'] = $this->config->fromEmail;
+			if (class_exists(Nette\Http\Request::class)) {
+				$senderParams['host'] = new Statement('($request = $this->getByType(?, false)) \? $request->getUrl()->getHost() : null', [Nette\Http\Request::class]);
+			}
+
 			$initialize->addBody($builder->formatPhp('if ($logger instanceof Tracy\Logger) $logger->mailer = ?;', [
-				[new Statement(Tracy\Bridges\Nette\MailSender::class, ['fromEmail' => $this->config->fromEmail]), 'send'],
+				[new Statement(Tracy\Bridges\Nette\MailSender::class, $senderParams), 'send'],
 			]));
 		}
 


### PR DESCRIPTION
- new feature? yes
- BC break? I don't think so

When  using nette behind proxy or in containers, server name is localhost. When nette/http is used, it reads actual host from proxy headers - https://github.com/nette/http/blob/7a92a2a61aaf2ebb74df11bb4a6f56daf20a1ef6/src/Http/RequestFactory.php#L294