### PR TITLE
Added checks if $_SERVER['argv'] is set

### DIFF
--- a/src/Tracy/BlueScreen/assets/section-cli.phtml
+++ b/src/Tracy/BlueScreen/assets/section-cli.phtml
@@ -18,15 +18,19 @@ if (!Helpers::isCli()) {
 
 	<div class="tracy-section-panel tracy-collapsed">
 		<h3>Process ID <?= Helpers::escapeHtml(getmypid()) ?></h3>
+<?php if (str_contains($source, '):')): ?>
 		<pre>php<?= Helpers::escapeHtml(explode('):', $source, 2)[1]) ?></pre>
+<?php endif; ?>
 
+<?php if (isset($_SERVER['argv'])): ?>
 		<h3>Arguments</h3>
 		<div class="tracy-pane">
 			<table>
-<?php foreach ($_SERVER['argv'] as $k => $v): ?>
+	<?php foreach ($_SERVER['argv'] as $k => $v): ?>
 				<tr><th><?= Helpers::escapeHtml($k) ?></th><td><?= $dump($v, $k) ?></td></tr>
-<?php endforeach ?>
+	<?php endforeach ?>
 			</table>
 		</div>
+<?php endif; ?>
 	</div>
 </section>


### PR DESCRIPTION
- bug fix
- BC break? no

Variable argv does not have to be present. First check relates to Helper class, which does not add column into source when run from cli and argv is missing
https://github.com/nette/tracy/blob/209ac3040406e31ac4ab20a06cfcd0513a719b36/src/Tracy/Helpers.php#L173

