### PR TITLE
Open-in-editor disable warning prompt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.10-dev"
+			"dev-master": "3.0-dev"
 		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -50,9 +50,9 @@ Alternatively, you can download the whole package or [tracy.phar](https://github
 
 | Tracy     | compatible with PHP | compatible with browsers
 |-----------|---------------|----------
-| Tracy 3.0 | PHP 8.0 – 8.3 | Chrome 64+, Firefox 69+, Safari 15.4+ and iOS Safari 15.4+
-| Tracy 2.10| PHP 8.0 – 8.3 | Chrome 64+, Firefox 69+, Safari 15.4+ and iOS Safari 15.4+
-| Tracy 2.9 | PHP 7.2 – 8.2 | Chrome 64+, Firefox 69+, Safari 13.1+ and iOS Safari 13.4+
+| Tracy 3.0 | PHP 8.0 – 8.3 | Chrome 112+, Firefox 117+, Safari 16.5+
+| Tracy 2.10| PHP 8.0 – 8.3 | Chrome 64+, Firefox 69+, Safari 15.4+
+| Tracy 2.9 | PHP 7.2 – 8.2 | Chrome 64+, Firefox 69+, Safari 13.1+
 
 
 Usage

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ Alternatively, you can download the whole package or [tracy.phar](https://github
 
 | Tracy     | compatible with PHP | compatible with browsers
 |-----------|---------------|----------
+| Tracy 3.0 | PHP 8.0 – 8.3 | Chrome 64+, Firefox 69+, Safari 15.4+ and iOS Safari 15.4+
 | Tracy 2.10| PHP 8.0 – 8.3 | Chrome 64+, Firefox 69+, Safari 15.4+ and iOS Safari 15.4+
 | Tracy 2.9 | PHP 7.2 – 8.2 | Chrome 64+, Firefox 69+, Safari 13.1+ and iOS Safari 13.4+
 

--- a/src/Bridges/Nette/Bridge.php
+++ b/src/Bridges/Nette/Bridge.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Tracy\Bridges\Nette;
 
-use Latte;
 use Nette;
 use Tracy;
 use Tracy\BlueScreen;
@@ -17,84 +16,15 @@ use Tracy\Helpers;
 
 
 /**
- * Bridge for NEON & Latte.
+ * Bridge for NEON.
  */
 class Bridge
 {
 	public static function initialize(): void
 	{
 		$blueScreen = Tracy\Debugger::getBlueScreen();
-		if (!class_exists(Latte\Bridges\Tracy\BlueScreenPanel::class)) {
-			$blueScreen->addPanel([self::class, 'renderLatteError']);
-			$blueScreen->addAction([self::class, 'renderLatteUnknownMacro']);
-			$blueScreen->addFileGenerator(fn(string $file) => substr($file, -6) === '.latte'
-					? "{block content}\n\$END\$"
-					: null);
-			Tracy\Debugger::addSourceMapper([self::class, 'mapLatteSourceCode']);
-		}
-
 		$blueScreen->addAction([self::class, 'renderMemberAccessException']);
 		$blueScreen->addPanel([self::class, 'renderNeonError']);
-	}
-
-
-	public static function renderLatteError(?\Throwable $e): ?array
-	{
-		if ($e instanceof Latte\CompileException && $e->sourceName) {
-			return [
-				'tab' => 'Template',
-				'panel' => (preg_match('#\n|\?#', $e->sourceName)
-						? ''
-						: '<p>'
-							. (@is_file($e->sourceName) // @ - may trigger error
-								? '<b>File:</b> ' . Helpers::editorLink($e->sourceName, $e->sourceLine)
-								: '<b>' . htmlspecialchars($e->sourceName . ($e->sourceLine ? ':' . $e->sourceLine : '')) . '</b>')
-							. '</p>')
-					. BlueScreen::highlightFile($e->sourceCode, $e->sourceLine, 15, false),
-			];
-		}
-
-		return null;
-	}
-
-
-	public static function renderLatteUnknownMacro(?\Throwable $e): ?array
-	{
-		if (
-			$e instanceof Latte\CompileException
-			&& $e->sourceName
-			&& @is_file($e->sourceName) // @ - may trigger error
-			&& (preg_match('#Unknown macro (\{\w+)\}, did you mean (\{\w+)\}\?#A', $e->getMessage(), $m)
-				|| preg_match('#Unknown attribute (n:\w+), did you mean (n:\w+)\?#A', $e->getMessage(), $m))
-		) {
-			return [
-				'link' => Helpers::editorUri($e->sourceName, $e->sourceLine, 'fix', $m[1], $m[2]),
-				'label' => 'fix it',
-			];
-		}
-
-		return null;
-	}
-
-
-	/** @return array{file: string, line: int, label: string, active: bool} */
-	public static function mapLatteSourceCode(string $file, int $line): ?array
-	{
-		if (!strpos($file, '.latte--')) {
-			return null;
-		}
-
-		$lines = file($file);
-		if (
-			!preg_match('#^/(?:\*\*|/) source: (\S+\.latte)#m', implode('', array_slice($lines, 0, 10)), $m)
-			|| !@is_file($m[1]) // @ - may trigger error
-		) {
-			return null;
-		}
-
-		$file = $m[1];
-		$line = $line && preg_match('#/\* line (\d+) \*/#', $lines[$line - 1], $m) ? (int) $m[1] : 0;
-		return ['file' => $file, 'line' => $line, 'label' => 'Latte', 'active' => true];
 	}
 
 

--- a/src/Bridges/Nette/TracyExtension.php
+++ b/src/Bridges/Nette/TracyExtension.php
@@ -130,7 +130,7 @@ class TracyExtension extends Nette\DI\CompilerExtension
 		if ($this->debugMode) {
 			foreach ($this->config->bar as $item) {
 				if (is_string($item) && substr($item, 0, 1) === '@') {
-					$item = new Statement(['@' . $builder::THIS_CONTAINER, 'getService'], [substr($item, 1)]);
+					$item = new Statement(['@' . $builder::ThisContainer, 'getService'], [substr($item, 1)]);
 				} elseif (is_string($item)) {
 					$item = new Statement($item);
 				}

--- a/src/Tracy/Bar/assets/bar.css
+++ b/src/Tracy/Bar/assets/bar.css
@@ -7,78 +7,73 @@
 	--tracy-space: 10px;
 	display: none;
 	direction: ltr;
-}
 
-body#tracy-debug { /* in popup window */
-	display: block;
-}
+	&:not(body) { /* not in popup window */
+		position: absolute;
+		left: 0;
+		top: 0;
+	}
 
-#tracy-debug:not(body) {
-	position: absolute;
-	left: 0;
-	top: 0;
-}
+	& a {
+		color: #125EAE;
+		text-decoration: none;
 
-#tracy-debug a {
-	color: #125EAE;
-	text-decoration: none;
-}
+		&:hover,
+		&:focus {
+			background-color: #125EAE;
+			color: white;
+		}
+	}
 
-#tracy-debug a:hover,
-#tracy-debug a:focus {
-	background-color: #125EAE;
-	color: white;
-}
+	& h2,
+	& h3 {
+		font-weight: bold;
+	}
 
-#tracy-debug h2,
-#tracy-debug h3 {
-	font-weight: bold;
-}
+	& table {
+		background: #FDF5CE;
+		width: 100%;
 
-#tracy-debug table {
-	background: #FDF5CE;
-	width: 100%;
-}
+		.tracy-right {
+			text-align: right;
+		}
+	}
 
-#tracy-debug tr:nth-child(2n) td {
-	background: rgba(0, 0, 0, 0.02);
-}
+	& tr:nth-child(2n) td {
+		background: rgba(0, 0, 0, 0.02);
+	}
 
-#tracy-debug td,
-#tracy-debug th {
-	border: 1px solid #E6DFBF;
-	padding: 2px 5px;
-	vertical-align: top;
-	text-align: left;
-}
+	& td,
+	& th {
+		border: 1px solid #E6DFBF;
+		padding: 2px 5px;
+		vertical-align: top;
+		text-align: left;
+	}
 
-#tracy-debug th {
-	background: #F4F3F1;
-	color: #655E5E;
-	font-size: 90%;
-	font-weight: bold;
-}
+	& th {
+		background: #F4F3F1;
+		color: #655E5E;
+		font-size: 90%;
+		font-weight: bold;
+	}
 
-#tracy-debug pre,
-#tracy-debug code {
-	font: 9pt/1.5 Consolas, monospace;
-}
+	& pre,
+	& code {
+		font: 9pt/1.5 Consolas, monospace;
+	}
 
-#tracy-debug table .tracy-right {
-	text-align: right;
-}
+	& svg {
+		display: inline;
+	}
 
-#tracy-debug svg {
-	display: inline;
-}
-
-#tracy-debug .tracy-dump {
-	margin: 0;
-	padding: 2px 5px;
+	.tracy-dump {
+		margin: 0;
+		padding: 2px 5px;
+	}
 }
 
 
-/* bar */
 #tracy-debug-bar {
 	font: normal normal 13px/1.55 Tahoma, sans-serif;
 	color: #333;
@@ -97,69 +92,71 @@ body#tracy-debug { /* in popup window */
 
 	border-radius: 3px;
 	box-shadow: 1px 1px 10px rgba(0, 0, 0, .15);
-}
 
-#tracy-debug-bar:hover {
-	opacity: 1;
-	transition: opacity 0.1s;
-}
+	&:hover {
+		opacity: 1;
+		transition: opacity 0.1s;
+	}
 
-#tracy-debug-bar .tracy-row {
-	list-style: none none;
-	display: flex;
-}
+	.tracy-row {
+		list-style: none none;
+		display: flex;
 
-#tracy-debug-bar .tracy-row:not(:first-child) {
-	background: #d5d2c6;
-	opacity: .8;
-}
+		&:not(:first-child) {
+			background: #d5d2c6;
+			opacity: .8;
+		}
 
-#tracy-debug-bar .tracy-row[data-tracy-group="ajax"] {
-	animation: tracy-row-flash .2s ease;
-}
+		&[data-tracy-group="ajax"] {
+			animation: tracy-row-flash .2s ease;
+		}
 
-@keyframes tracy-row-flash {
-	0% {
-		background: #c9c0a0;
+		@keyframes tracy-row-flash {
+			0% {
+				background: #c9c0a0;
+			}
+		}
+
+		&:not(:first-child) li:first-child {
+			width: 4.1em;
+			text-align: center;
+		}
+	}
+
+
+	& img {
+		vertical-align: bottom;
+		position: relative;
+		top: -2px;
+	}
+
+	& svg {
+		vertical-align: bottom;
+		width: 1.23em;
+		height: 1.55em;
+	}
+
+	.tracy-label {
+		margin-left: .2em;
+	}
+
+	& li > a,
+	& li > span {
+		color: #000;
+		display: block;
+		padding: 0 .4em;
+	}
+
+	& li > a:hover {
+		color: black;
+		background: #c3c1b8;
+	}
+
+	& li:first-child {
+		cursor: move;
 	}
 }
 
-#tracy-debug-bar .tracy-row:not(:first-child) li:first-child {
-	width: 4.1em;
-	text-align: center;
-}
-
-#tracy-debug-bar img {
-	vertical-align: bottom;
-	position: relative;
-	top: -2px;
-}
-
-#tracy-debug-bar svg {
-	vertical-align: bottom;
-	width: 1.23em;
-	height: 1.55em;
-}
-
-#tracy-debug-bar .tracy-label {
-	margin-left: .2em;
-}
-
-#tracy-debug-bar li > a,
-#tracy-debug-bar li > span {
-	color: #000;
-	display: block;
-	padding: 0 .4em;
-}
-
-#tracy-debug-bar li > a:hover {
-	color: black;
-	background: #c3c1b8;
-}
-
-#tracy-debug-bar li:first-child {
-	cursor: move;
-}
 
 #tracy-debug-logo svg {
 	width: 3.4em;
@@ -168,137 +165,135 @@ body#tracy-debug { /* in popup window */
 
 
 /* panels */
-#tracy-debug .tracy-panel {
-	display: none;
-	font: normal normal 12px/1.5 sans-serif;
-	background: white;
-	color: #333;
-	text-align: left;
-}
-
-body#tracy-debug .tracy-panel { /* in popup window */
-	display: block;
-}
-
-#tracy-debug h1 {
-	font: normal normal 23px/1.4 Tahoma, sans-serif;
-	color: #575753;
-	margin: -5px -5px var(--tracy-space);
-	padding: 0 5px 0 5px;
-	word-wrap: break-word;
-}
-
-#tracy-debug .tracy-inner {
-	overflow: auto;
-	flex: 1;
-}
-
-#tracy-debug .tracy-panel .tracy-icons {
-	display: none;
-}
-
-#tracy-debug .tracy-panel-ajax h1::after,
-#tracy-debug .tracy-panel-redirect h1::after {
-	content: 'ajax';
-	float: right;
-	font-size: 65%;
-	margin: 0 .3em;
-}
-
-#tracy-debug .tracy-panel-redirect h1::after {
-	content: 'redirect';
-}
-
-#tracy-debug .tracy-mode-peek,
-#tracy-debug .tracy-mode-float {
-	position: fixed;
-	flex-direction: column;
-	padding: var(--tracy-space);
-	min-width: 200px;
-	min-height: 80px;
-	border-radius: 5px;
-	box-shadow: 1px 1px 20px rgba(102, 102, 102, 0.36);
-	border: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-#tracy-debug .tracy-mode-peek,
-#tracy-debug .tracy-mode-float:not(.tracy-panel-resized) {
-	max-width: 700px;
-	max-height: 500px;
-}
-
-@media (max-height: 555px) {
-	#tracy-debug .tracy-mode-peek,
-	#tracy-debug .tracy-mode-float:not(.tracy-panel-resized) {
-		max-height: 100vh;
+#tracy-debug {
+	.tracy-panel {
+		display: none;
+		font: normal normal 12px/1.5 sans-serif;
+		background: white;
+		color: #333;
+		text-align: left;
 	}
-}
 
-#tracy-debug .tracy-mode-peek h1 {
-	cursor: move;
-}
+	& h1 {
+		font: normal normal 23px/1.4 Tahoma, sans-serif;
+		color: #575753;
+		margin: -5px -5px var(--tracy-space);
+		padding: 0 5px 0 5px;
+		word-wrap: break-word;
+	}
 
-#tracy-debug .tracy-mode-float {
-	display: flex;
-	opacity: .95;
-	transition: opacity 0.2s;
-	will-change: opacity, top, left;
-	overflow: auto;
-	resize: both;
-}
+	.tracy-inner {
+		overflow: auto;
+		flex: 1;
+	}
 
-#tracy-debug .tracy-focused {
-	display: flex;
-	opacity: 1;
-	transition: opacity 0.1s;
-}
-
-#tracy-debug .tracy-mode-float h1 {
-	cursor: move;
-	padding-right: 25px;
-}
-
-#tracy-debug .tracy-mode-float .tracy-icons {
-	display: block;
-	position: absolute;
-	top: 0;
-	right: 5px;
-	font-size: 18px;
-}
-
-#tracy-debug .tracy-mode-window {
-	padding: var(--tracy-space);
-}
-
-#tracy-debug .tracy-icons a {
-	color: #575753;
-}
-
-#tracy-debug .tracy-icons a:hover {
-	color: white;
-}
-
-
-#tracy-debug .tracy-inner-container {
-	min-width: 100%;
-	float: left;
-	/* explicit gaps: */
-	display: flex;
-	flex-direction: column;
-	gap: var(--tracy-space);
-}
-
-#tracy-debug .tracy-inner-container > * {
-	margin-bottom: 0; /* disable implicit gaps */
-}
-
-#tracy-debug .tracy-inner-container:not(:last-child) {
-	margin-bottom: var(--tracy-space);
-}
-
-
-@media print {
-	#tracy-debug * {
+	.tracy-panel .tracy-icons {
 		display: none;
 	}
+
+	.tracy-panel-ajax h1::after,
+	.tracy-panel-redirect h1::after {
+		content: 'ajax';
+		float: right;
+		font-size: 65%;
+		margin: 0 .3em;
+	}
+
+	.tracy-panel-redirect h1::after {
+		content: 'redirect';
+	}
+
+	.tracy-mode-peek,
+	.tracy-mode-float {
+		position: fixed;
+		flex-direction: column;
+		padding: var(--tracy-space);
+		min-width: 200px;
+		min-height: 80px;
+		border-radius: 5px;
+		box-shadow: 1px 1px 20px rgba(102, 102, 102, 0.36);
+		border: 1px solid rgba(0, 0, 0, 0.1);
+	}
+
+	.tracy-mode-peek,
+	.tracy-mode-float:not(.tracy-panel-resized) {
+		max-width: 700px;
+		max-height: 500px;
+
+		@media (max-height: 555px) {
+			max-height: 100vh;
+		}
+	}
+
+	.tracy-mode-peek h1 {
+		cursor: move;
+	}
+
+	.tracy-mode-float {
+		display: flex;
+		opacity: .95;
+		transition: opacity 0.2s;
+		will-change: opacity, top, left;
+		overflow: auto;
+		resize: both;
+	}
+
+	.tracy-focused {
+		display: flex;
+		opacity: 1;
+		transition: opacity 0.1s;
+	}
+
+	.tracy-mode-float h1 {
+		cursor: move;
+		padding-right: 25px;
+	}
+
+	.tracy-mode-float .tracy-icons {
+		display: block;
+		position: absolute;
+		top: 0;
+		right: 5px;
+		font-size: 18px;
+	}
+
+	.tracy-mode-window {
+		padding: var(--tracy-space);
+	}
+
+	.tracy-icons a {
+		color: #575753;
+
+		&:hover {
+			color: white;
+		}
+	}
+
+
+	.tracy-inner-container {
+		min-width: 100%;
+		float: left;
+		/* explicit gaps: */
+		display: flex;
+		flex-direction: column;
+		gap: var(--tracy-space);
+
+		& > * {
+			margin-bottom: 0; /* disable implicit gaps */
+		}
+
+		&:not(:last-child) {
+			margin-bottom: var(--tracy-space);
+		}
+	}
+
+
+	@media print {
+		display: none;
+	}
+}
+
+
+body#tracy-debug { /* in popup window */
+	display: block;
 }

--- a/src/Tracy/Bar/assets/bar.css
+++ b/src/Tracy/Bar/assets/bar.css
@@ -30,6 +30,10 @@ body#tracy-debug { /* in popup window */
 	color: white;
 }
 
+#tracy-debug h2,
+#tracy-debug h3 {
+	font-weight: bold;
+}
 
 #tracy-debug table {
 	background: #FDF5CE;

--- a/src/Tracy/Bar/assets/bar.css
+++ b/src/Tracy/Bar/assets/bar.css
@@ -4,6 +4,7 @@
 
 /* common styles */
 #tracy-debug {
+	--tracy-space: 10px;
 	display: none;
 	direction: ltr;
 }
@@ -29,11 +30,6 @@ body#tracy-debug { /* in popup window */
 	color: white;
 }
 
-#tracy-debug h2,
-#tracy-debug h3,
-#tracy-debug p {
-	margin: .4em 0;
-}
 
 #tracy-debug table {
 	background: #FDF5CE;
@@ -183,7 +179,7 @@ body#tracy-debug .tracy-panel { /* in popup window */
 #tracy-debug h1 {
 	font: normal normal 23px/1.4 Tahoma, sans-serif;
 	color: #575753;
-	margin: -5px -5px 5px;
+	margin: -5px -5px var(--tracy-space);
 	padding: 0 5px 0 5px;
 	word-wrap: break-word;
 }
@@ -213,7 +209,7 @@ body#tracy-debug .tracy-panel { /* in popup window */
 #tracy-debug .tracy-mode-float {
 	position: fixed;
 	flex-direction: column;
-	padding: 10px;
+	padding: var(--tracy-space);
 	min-width: 200px;
 	min-height: 80px;
 	border-radius: 5px;
@@ -267,7 +263,7 @@ body#tracy-debug .tracy-panel { /* in popup window */
 }
 
 #tracy-debug .tracy-mode-window {
-	padding: 10px;
+	padding: var(--tracy-space);
 }
 
 #tracy-debug .tracy-icons a {
@@ -282,7 +278,20 @@ body#tracy-debug .tracy-panel { /* in popup window */
 #tracy-debug .tracy-inner-container {
 	min-width: 100%;
 	float: left;
+	/* explicit gaps: */
+	display: flex;
+	flex-direction: column;
+	gap: var(--tracy-space);
 }
+
+#tracy-debug .tracy-inner-container > * {
+	margin-bottom: 0; /* disable implicit gaps */
+}
+
+#tracy-debug .tracy-inner-container:not(:last-child) {
+	margin-bottom: var(--tracy-space);
+}
+
 
 @media print {
 	#tracy-debug * {

--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -387,7 +387,7 @@ class BlueScreen
 					);
 				}
 				$out .= sprintf(
-					"<span class='tracy-line-highlight'>%{$numWidth}s:    %s\n</span>%s",
+					"<span class='tracy-line-highlight'>%{$numWidth}s:    %s</span>\n%s",
 					$n,
 					$s,
 					implode('', $tags[0]),

--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -412,34 +412,18 @@ class BlueScreen
 			return null;
 		}
 
-		$s = self::highlightPhp($source, $line, $lines);
-
-		$colors = [
-			'color: ' . ini_get('highlight.comment') => '1;30',
-			'color: ' . ini_get('highlight.default') => '1;36',
-			'color: ' . ini_get('highlight.html') => '1;35',
-			'color: ' . ini_get('highlight.keyword') => '1;37',
-			'color: ' . ini_get('highlight.string') => '1;32',
-			'tracy-line' => '1;30',
-			'tracy-line-highlight' => "1;37m\e[41",
-		];
-
-		$stack = ['0'];
-		$s = preg_replace_callback(
-			'#<\w+(?: (class|style)=["\'](.*?)["\'])?[^>]*>|</\w+>#',
-			function ($m) use ($colors, &$stack): string {
-				if ($m[0][1] === '/') {
-					array_pop($stack);
-				} else {
-					$stack[] = isset($m[2], $colors[$m[2]]) ? $colors[$m[2]] : '0';
-				}
-
-				return "\e[0m\e[" . end($stack) . 'm';
-			},
-			$s,
+		return Helpers::htmlToAnsi(
+			self::highlightPhp($source, $line, $lines),
+			[
+				'color: ' . ini_get('highlight.comment') => '1;30',
+				'color: ' . ini_get('highlight.default') => '1;36',
+				'color: ' . ini_get('highlight.html') => '1;35',
+				'color: ' . ini_get('highlight.keyword') => '1;37',
+				'color: ' . ini_get('highlight.string') => '1;32',
+				'tracy-line' => '1;30',
+				'tracy-line-highlight' => "1;37m\e[41",
+			],
 		);
-		$s = htmlspecialchars_decode(strip_tags($s), ENT_QUOTES | ENT_HTML5);
-		return $s;
 	}
 
 

--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -132,7 +132,7 @@ class BlueScreen
 		if ($handle = @fopen($file, 'x')) {
 			ob_start(); // double buffer prevents sending HTTP headers in some PHP
 			ob_start(function ($buffer) use ($handle): void { fwrite($handle, $buffer); }, 4096);
-			$this->renderTemplate($exception, __DIR__ . '/assets/page.phtml', false);
+			$this->renderTemplate($exception, __DIR__ . '/assets/page.phtml', toScreen: false);
 			ob_end_flush();
 			ob_end_clean();
 			fclose($handle);
@@ -478,7 +478,7 @@ class BlueScreen
 
 	public function formatMessage(\Throwable $exception): string
 	{
-		$msg = Helpers::encodeString(trim((string) $exception->getMessage()), self::MaxMessageLength, false);
+		$msg = Helpers::encodeString(trim((string) $exception->getMessage()), self::MaxMessageLength, showWhitespaces: false);
 
 		// highlight 'string'
 		$msg = preg_replace(

--- a/src/Tracy/BlueScreen/CodeHighlighter.php
+++ b/src/Tracy/BlueScreen/CodeHighlighter.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the Tracy (https://tracy.nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Tracy;
+
+
+/** @internal */
+final class CodeHighlighter
+{
+	private const DisplayLines = 15;
+
+
+	/**
+	 * Extract a snippet from the code, highlights the row and column, and adds line numbers.
+	 */
+	public static function highlightLine(string $html, int $line, int $column = 0): string
+	{
+		$source = explode("\n", "\n" . str_replace("\r\n", "\n", $html));
+		$out = '';
+		$spans = 1;
+		$start = $i = max(1, min($line, count($source) - 1) - (int) floor(self::DisplayLines * 2 / 3));
+		while (--$i >= 1) { // find last highlighted block
+			if (preg_match('#.*(</?span[^>]*>)#', $source[$i], $m)) {
+				if ($m[1] !== '</span>') {
+					$spans++;
+					$out .= $m[1];
+				}
+
+				break;
+			}
+		}
+
+		$source = array_slice($source, $start, self::DisplayLines, true);
+		end($source);
+		$numWidth = strlen((string) key($source));
+
+		foreach ($source as $n => $s) {
+			$spans += substr_count($s, '<span') - substr_count($s, '</span');
+			$s = str_replace(["\r", "\n"], ['', ''], $s);
+			preg_match_all('#<[^>]+>#', $s, $tags);
+			if ($n == $line) {
+				$s = strip_tags($s);
+				if ($column) {
+					$s = preg_replace(
+						'#((?:&.*?;|[^&]){' . ($column - 1) . '})(&.*?;|.)#u',
+						'\1<span class="tracy-column-highlight">\2</span>',
+						$s . ' ',
+						1,
+					);
+				}
+				$out .= sprintf(
+					"<span class='tracy-line-highlight'>%{$numWidth}s:    %s</span>\n%s",
+					$n,
+					$s,
+					implode('', $tags[0]),
+				);
+			} else {
+				$out .= sprintf("<span class='tracy-line'>%{$numWidth}s:</span>    %s\n", $n, $s);
+			}
+		}
+
+		$out .= str_repeat('</span>', $spans) . '</code>';
+		return $out;
+	}
+
+
+	/**
+	 * Returns syntax highlighted source code.
+	 */
+	public static function highlightPhp(string $code, int $line, int $column = 0): string
+	{
+		if (function_exists('ini_set')) {
+			ini_set('highlight.comment', '#998; font-style: italic');
+			ini_set('highlight.default', '#000');
+			ini_set('highlight.html', '#06B');
+			ini_set('highlight.keyword', '#D24; font-weight: bold');
+			ini_set('highlight.string', '#080');
+		}
+
+		$source = preg_replace('#(__halt_compiler\s*\(\)\s*;).*#is', '$1', $code);
+		$source = str_replace(["\r\n", "\r"], "\n", $source);
+		$source = preg_replace('#/\*sensitive\{\*/.*?/\*\}\*/#s', Dumper\Describer::HiddenValue, $source);
+		$source = explode("\n", highlight_string($source, true));
+		$out = $source[0]; // <code><span color=highlight.html>
+		$source = str_replace('<br />', "\n", $source[1]);
+		$out .= self::highlightLine($source, $line, $column);
+		$out = str_replace('&nbsp;', ' ', $out);
+		return "<pre class='tracy-code'><div>$out</div></pre>";
+	}
+
+
+	/**
+	 * Returns syntax highlighted source code to Terminal.
+	 */
+	public static function highlightPhpCli(string $code, int $line, int $column = 0): string
+	{
+		return Helpers::htmlToAnsi(
+			self::highlightPhp($code, $line, $column),
+			[
+				'color: ' . ini_get('highlight.comment') => '1;30',
+				'color: ' . ini_get('highlight.default') => '1;36',
+				'color: ' . ini_get('highlight.html') => '1;35',
+				'color: ' . ini_get('highlight.keyword') => '1;37',
+				'color: ' . ini_get('highlight.string') => '1;32',
+				'tracy-line' => '1;30',
+				'tracy-line-highlight' => "1;37m\e[41",
+			],
+		);
+	}
+}

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -267,6 +267,20 @@ html.tracy-bs-visible body {
 	white-space: pre;
 }
 
+#tracy-bs .tracy-code-comment {
+	color: rgba(0, 0, 0, 0.5);
+	font-style: italic;
+}
+
+#tracy-bs .tracy-code-keyword {
+	color: #D24;
+	font-weight: bold;
+}
+
+#tracy-bs .tracy-code-var {
+	font-weight: bold;
+}
+
 #tracy-bs .tracy-line-highlight {
 	background: #CD1818;
 	color: white;

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -274,7 +274,7 @@ html.tracy-bs-visible body {
 	font-style: normal;
 	display: block;
 	padding: 0 1ch;
-	margin: 0 -1ch;
+	margin: 0 -1ch -1lh;
 }
 
 #tracy-bs .tracy-column-highlight {

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -19,405 +19,403 @@ html.tracy-bs-visible body {
 	top: 0;
 	width: 100%;
 	text-align: left;
-}
 
-@media (max-width: 600px) {
-	#tracy-bs {
+	@media (max-width: 600px) {
 		--tracy-space: 8px;
 	}
-}
 
-#tracy-bs a {
-	text-decoration: none;
-	color: #328ADC;
-	padding: 0 4px;
-	margin: 0 -4px;
-}
+	& a {
+		text-decoration: none;
+		color: #328ADC;
+		padding: 0 4px;
+		margin: 0 -4px;
 
-#tracy-bs a + a {
-	margin-left: 0;
-}
-
-#tracy-bs a:hover,
-#tracy-bs a:focus {
-	color: #085AA3;
-}
-
-#tracy-bs-toggle {
-	position: absolute;
-	right: .5em;
-	top: .5em;
-	text-decoration: none;
-	background: #CD1818;
-	color: white !important;
-	padding: 3px;
-}
-
-#tracy-bs-toggle.tracy-collapsed {
-	position: fixed;
-}
-
-.tracy-bs-main {
-	display: flex;
-	flex-direction: column;
-	padding-bottom: 80vh;
-}
-
-.tracy-bs-main.tracy-collapsed {
-	display: none;
-}
-
-#tracy-bs h1 {
-	font-size: 15pt;
-	font-weight: normal;
-	text-shadow: 1px 1px 2px rgba(0, 0, 0, .3);
-}
-
-#tracy-bs h1 span {
-	white-space: pre-wrap;
-}
-
-#tracy-bs h2 {
-	font-size: 14pt;
-	font-weight: normal;
-}
-
-#tracy-bs h3 {
-	font-size: 10pt;
-	font-weight: bold;
-}
-
-#tracy-bs pre,
-#tracy-bs code,
-#tracy-bs table {
-	font: 9pt/1.5 Consolas, monospace !important;
-}
-
-#tracy-bs pre,
-#tracy-bs table {
-	background: #FDF5CE;
-	padding: .4em .7em;
-	border: 2px solid #ffffffa6;
-	box-shadow: 1px 2px 6px #00000005;
-	overflow: auto;
-}
-
-#tracy-bs table pre {
-	padding: 0;
-	margin: 0;
-	border: none;
-	box-shadow: none;
-}
-
-#tracy-bs table {
-	border-collapse: collapse;
-	width: 100%;
-}
-
-#tracy-bs td,
-#tracy-bs th {
-	vertical-align: top;
-	text-align: left;
-	padding: 2px 6px;
-	border: 1px solid #e6dfbf;
-}
-
-#tracy-bs th {
-	font-weight: bold;
-}
-
-#tracy-bs tr > :first-child {
-	width: 20%;
-}
-
-#tracy-bs tr:nth-child(2n),
-#tracy-bs tr:nth-child(2n) pre {
-	background-color: #F7F0CB;
-}
-
-#tracy-bs .tracy-footer--sticky {
-	position: fixed;
-	width: 100%;
-	bottom: 0;
-}
-
-#tracy-bs footer ul {
-	font-size: 7pt;
-	padding: var(--tracy-space);
-	margin: var(--tracy-space) 0 0;
-	color: #777;
-	background: #F6F5F3;
-	border-top: 1px solid #DDD;
-	list-style: none;
-}
-
-#tracy-bs .tracy-footer-logo {
-	position: relative;
-}
-
-#tracy-bs .tracy-footer-logo a {
-	position: absolute;
-	bottom: 0;
-	right: 0;
-	width: 100px;
-	height: 50px;
-	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFoAAAAUBAMAAAD/1DctAAAAMFBMVEWupZzj39rEvbTy8O3X0sz9/PvGwLu8tavQysHq6OS0rKP5+Pbd2dT29fPMxbzPx8DKErMJAAAACXBIWXMAAAsTAAALEwEAmpwYAAACGUlEQVQoFX3TQWgTQRQA0MWLIJJDYehBTykhG5ERTx56K1u8eEhCYtomE7x5L4iLh0ViF7egewuFFqSIYE6hIHsIYQ6CQSg9CDKn4QsNCRlB59C74J/ZNHW1+An5+bOPyf6/s46oz2P+A0yIeZZ2ieEHi6TOnLKTxvWq+b52mxlVO3xnM1s7xLX1504XQH65OnW2dBqn7cCkYsFsfYsWpyY/2salmFTpEyzeR8zosYqMdiPDXdyU52K1wgEa/SjGpdEwUAxqvRfckQCDOyFearsEHe2grvkh/cFAHKvdtI3lcVceKQIOFpv+FOZaNPQBwJZLPp+hfrvT5JZXaUFsR8zqQc9qSgAharkfS5M/5F6nGJJAtXq/eLr3ucZpHccSxOOIPaQhtHohpCH2Xu6rLmQ0djnr4/+J3C6v+AW8/XWYxwYNdlhWj/P5fPSTQwVr0T9lGxdaBCqErNZaqYnEwbkjEB3NasGF3lPdrHa1nnxNOMgj0+neePUPjd2v/qVvUv29ifvc19huQ48qwXShy/9o8o3OSk0cs37mOFd0Ydgvsf/oZEnPVtggfd66lORn9mDyyzXU13SRtH2L6aR5T/snGAcZPfAXz5J1YlJWBEuxdMYqQecpBrlM49xAbmqyHA+xlA1FxBtqT2xmJoNXZlIt74ZBLeJ9ZGDqByNI7p543idzJ23vXEv7IgnsxiS+eNtwNbFdLq7+Bi4wQ0I4SVb9AAAAAElFTkSuQmCC') no-repeat;
-	opacity: .6;
-	padding: 0;
-	margin: 0;
-}
-
-#tracy-bs .tracy-footer-logo a:hover,
-#tracy-bs .tracy-footer-logo a:focus {
-	opacity: 1;
-	transition: opacity 0.1s;
-}
-
-
-#tracy-bs .tracy-section {
-	padding: var(--tracy-space);
-}
-
-#tracy-bs .tracy-section-panel {
-	background: #F4F3F1;
-	padding: var(--tracy-space);
-	border-radius: 8px;
-	box-shadow: inset 1px 1px 0px 0 #00000005;
-	overflow: hidden;
-}
-
-#tracy-bs .outer, /* deprecated */
-#tracy-bs .tracy-pane {
-	overflow: auto;
-}
-
-#tracy-bs .tracy-pane:not(:last-child) {
-	margin-bottom: var(--tracy-space);
-}
-
-#tracy-bs.tracy-mac .tracy-pane {
-	padding-bottom: 12px;
-}
-
-
-/* header */
-#tracy-bs .tracy-section--error {
-	background: #CD1818;
-	color: white;
-	font-size: 13pt;
-}
-
-#tracy-bs .tracy-section--error h1 {
-	color: white;
-}
-
-#tracy-bs .tracy-section--error::selection,
-#tracy-bs .tracy-section--error ::selection {
-	color: black !important;
-	background: #FDF5CE !important;
-}
-
-#tracy-bs .tracy-section--error a {
-	color: #ffefa1 !important;
-}
-
-#tracy-bs .tracy-section--error span span {
-	font-size: 80%;
-	color: rgba(255, 255, 255, 0.5);
-	text-shadow: none;
-}
-
-#tracy-bs .tracy-section--error a.tracy-action {
-	color: white !important;
-	opacity: 0;
-	font-size: .7em;
-	border-bottom: none !important;
-}
-
-#tracy-bs .tracy-section--error:hover a.tracy-action {
-	opacity: .6;
-}
-
-#tracy-bs .tracy-section--error a.tracy-action:hover {
-	opacity: 1;
-}
-
-#tracy-bs .tracy-section--error i {
-	color: #ffefa1;
-	font-style: normal;
-}
-
-
-/* source code */
-#tracy-bs pre.tracy-code > div {
-	min-width: 100%;
-	float: left;
-	white-space: pre;
-}
-
-#tracy-bs .tracy-code-comment {
-	color: rgba(0, 0, 0, 0.5);
-	font-style: italic;
-}
-
-#tracy-bs .tracy-code-keyword {
-	color: #D24;
-	font-weight: bold;
-}
-
-#tracy-bs .tracy-code-var {
-	font-weight: bold;
-}
-
-#tracy-bs .tracy-line-highlight {
-	background: #CD1818;
-	color: white;
-	font-weight: bold;
-	font-style: normal;
-	display: block;
-	padding: 0 1ch;
-	margin: 0 -1ch -1lh;
-}
-
-#tracy-bs .tracy-column-highlight {
-	display: inline-block;
-	backdrop-filter: grayscale(1);
-	margin: 0 -1px;
-	padding: 0 1px;
-}
-
-#tracy-bs .tracy-line {
-	color: #9F9C7F;
-	font-weight: normal;
-	font-style: normal;
-}
-
-#tracy-bs a.tracy-editor {
-	color: inherit;
-	border-bottom: 1px dotted rgba(0, 0, 0, .3);
-	border-radius: 3px;
-}
-
-#tracy-bs a.tracy-editor:hover {
-	background: #0001;
-}
-
-#tracy-bs span[data-tracy-href] {
-	border-bottom: 1px dotted rgba(0, 0, 0, .3);
-}
-
-#tracy-bs .tracy-dump-whitespace {
-	color: #0003;
-}
-
-#tracy-bs .tracy-caused {
-	float: right;
-	padding: .3em calc(1.5 * var(--tracy-space));
-	background: #df8075;
-	border-radius: 0 0 0 8px;
-	white-space: nowrap;
-}
-
-#tracy-bs .tracy-caused a {
-	color: white;
-}
-
-#tracy-bs .tracy-callstack {
-	display: grid;
-	grid-template-columns: max-content 1fr;
-}
-
-#tracy-bs .tracy-callstack-file {
-	text-align: right;
-	padding-right: var(--tracy-space);
-	white-space: nowrap;
-	height: calc(1.5 * var(--tracy-space));
-}
-
-#tracy-bs .tracy-callstack-callee {
-	white-space: nowrap;
-	height: calc(1.5 * var(--tracy-space));
-}
-
-#tracy-bs .tracy-callstack-additional {
-	grid-column-start: 1;
-	grid-column-end: 3;
-}
-
-#tracy-bs .tracy-callstack-additional:not(:last-child) {
-	margin-bottom: var(--tracy-space);
-}
-
-#tracy-bs .tracy-callstack-args tr:first-child > * {
-	position: relative;
-}
-
-#tracy-bs .tracy-callstack-args tr:first-child td:before {
-	position: absolute;
-	right: .3em;
-	content: 'may not be true';
-	opacity: .4;
-}
-
-#tracy-bs .tracy-panel-fadein {
-	animation: tracy-panel-fadein .12s ease;
-}
-
-@keyframes tracy-panel-fadein {
-	0% {
-		opacity: 0;
+		&:hover,
+		&:focus {
+			color: #085AA3;
+		}
 	}
-}
 
-#tracy-bs .tracy-section--causedby {
-	flex-direction: column;
-	padding: 0;
-}
+	& a + a {
+		margin-left: 0;
+	}
 
-#tracy-bs .tracy-section--causedby:not(.tracy-collapsed) {
-	display: flex;
-}
+	#tracy-bs-toggle {
+		position: absolute;
+		right: .5em;
+		top: .5em;
+		text-decoration: none;
+		background: #CD1818;
+		color: white !important;
+		padding: 3px;
 
-#tracy-bs .tracy-section--causedby .tracy-section--error {
-	background: #cd1818a6;
-}
+		&.tracy-collapsed {
+			position: fixed;
+		}
+	}
 
-#tracy-bs .tracy-section--error + .tracy-section--stack {
-	margin-top: calc(1.5 * var(--tracy-space));
-}
+	.tracy-bs-main {
+		display: flex;
+		flex-direction: column;
+		padding-bottom: 80vh;
+
+		&.tracy-collapsed {
+			display: none;
+		}
+	}
+
+	& h1 {
+		font-size: 15pt;
+		font-weight: normal;
+		text-shadow: 1px 1px 2px rgba(0, 0, 0, .3);
+
+		& span {
+			white-space: pre-wrap;
+		}
+	}
+
+	& h2 {
+		font-size: 14pt;
+		font-weight: normal;
+	}
+
+	& h3 {
+		font-size: 10pt;
+		font-weight: bold;
+	}
+
+	& pre,
+	& code,
+	& table {
+		font: 9pt/1.5 Consolas, monospace !important;
+	}
+
+	& pre,
+	& table {
+		background: #FDF5CE;
+		padding: .4em .7em;
+		border: 2px solid #ffffffa6;
+		box-shadow: 1px 2px 6px #00000005;
+		overflow: auto;
+	}
+
+	& table {
+		border-collapse: collapse;
+		width: 100%;
+
+		& pre {
+			padding: 0;
+			margin: 0;
+			border: none;
+			box-shadow: none;
+		}
+	}
+
+	& td,
+	& th {
+		vertical-align: top;
+		text-align: left;
+		padding: 2px 6px;
+		border: 1px solid #e6dfbf;
+	}
+
+	& th {
+		font-weight: bold;
+	}
+
+	& tr > :first-child {
+		width: 20%;
+	}
+
+	& tr:nth-child(2n),
+	& tr:nth-child(2n) pre {
+		background-color: #F7F0CB;
+	}
+
+	.tracy-footer--sticky {
+		position: fixed;
+		width: 100%;
+		bottom: 0;
+	}
+
+	& footer ul {
+		font-size: 7pt;
+		padding: var(--tracy-space);
+		margin: var(--tracy-space) 0 0;
+		color: #777;
+		background: #F6F5F3;
+		border-top: 1px solid #DDD;
+		list-style: none;
+	}
+
+	.tracy-footer-logo {
+		position: relative;
+
+		& a {
+			position: absolute;
+			bottom: 0;
+			right: 0;
+			width: 100px;
+			height: 50px;
+			background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFoAAAAUBAMAAAD/1DctAAAAMFBMVEWupZzj39rEvbTy8O3X0sz9/PvGwLu8tavQysHq6OS0rKP5+Pbd2dT29fPMxbzPx8DKErMJAAAACXBIWXMAAAsTAAALEwEAmpwYAAACGUlEQVQoFX3TQWgTQRQA0MWLIJJDYehBTykhG5ERTx56K1u8eEhCYtomE7x5L4iLh0ViF7egewuFFqSIYE6hIHsIYQ6CQSg9CDKn4QsNCRlB59C74J/ZNHW1+An5+bOPyf6/s46oz2P+A0yIeZZ2ieEHi6TOnLKTxvWq+b52mxlVO3xnM1s7xLX1504XQH65OnW2dBqn7cCkYsFsfYsWpyY/2salmFTpEyzeR8zosYqMdiPDXdyU52K1wgEa/SjGpdEwUAxqvRfckQCDOyFearsEHe2grvkh/cFAHKvdtI3lcVceKQIOFpv+FOZaNPQBwJZLPp+hfrvT5JZXaUFsR8zqQc9qSgAharkfS5M/5F6nGJJAtXq/eLr3ucZpHccSxOOIPaQhtHohpCH2Xu6rLmQ0djnr4/+J3C6v+AW8/XWYxwYNdlhWj/P5fPSTQwVr0T9lGxdaBCqErNZaqYnEwbkjEB3NasGF3lPdrHa1nnxNOMgj0+neePUPjd2v/qVvUv29ifvc19huQ48qwXShy/9o8o3OSk0cs37mOFd0Ydgvsf/oZEnPVtggfd66lORn9mDyyzXU13SRtH2L6aR5T/snGAcZPfAXz5J1YlJWBEuxdMYqQecpBrlM49xAbmqyHA+xlA1FxBtqT2xmJoNXZlIt74ZBLeJ9ZGDqByNI7p543idzJ23vXEv7IgnsxiS+eNtwNbFdLq7+Bi4wQ0I4SVb9AAAAAElFTkSuQmCC') no-repeat;
+			opacity: .6;
+			padding: 0;
+			margin: 0;
+
+			&:hover,
+			&:focus {
+				opacity: 1;
+				transition: opacity 0.1s;
+			}
+		}
+	}
 
 
-/* tabs */
-#tracy-bs .tracy-tab-bar {
-	display: flex;
-	list-style: none;
-	padding-left: 0;
-	margin: 0;
-	width: 100%;
-	font-size: 110%;
-}
+	.tracy-section {
+		padding: var(--tracy-space);
+	}
 
-#tracy-bs .tracy-tab-bar > *:not(:first-child) {
-	margin-left: var(--tracy-space);
-}
+	.tracy-section-panel {
+		background: #F4F3F1;
+		padding: var(--tracy-space);
+		border-radius: 8px;
+		box-shadow: inset 1px 1px 0px 0 #00000005;
+		overflow: hidden;
+	}
 
-#tracy-bs .tracy-tab-bar a {
-	display: block;
-	padding: calc(.5 * var(--tracy-space)) var(--tracy-space);
-	margin: 0;
-	height: 100%;
-	box-sizing: border-box;
-	border-radius: 5px 5px 0 0;
-	text-decoration: none;
-	transition: all 0.1s;
-}
+	.outer, /* deprecated */
+	.tracy-pane {
+		overflow: auto;
+	}
 
-#tracy-bs .tracy-tab-bar > .tracy-active a {
-	background: white;
-}
+	.tracy-pane:not(:last-child) {
+		margin-bottom: var(--tracy-space);
+	}
 
-#tracy-bs .tracy-tab-panel {
-	border-top: 2px solid white;
-	padding-top: var(--tracy-space);
-	overflow: auto;
+	&.tracy-mac .tracy-pane {
+		padding-bottom: 12px;
+	}
+
+
+	/* header */
+	.tracy-section--error {
+		background: #CD1818;
+		color: white;
+		font-size: 13pt;
+
+		& h1 {
+			color: white;
+		}
+
+		&::selection,
+		& ::selection {
+			color: black !important;
+			background: #FDF5CE !important;
+		}
+
+		& a {
+			color: #ffefa1 !important;
+		}
+
+		& span span {
+			font-size: 80%;
+			color: rgba(255, 255, 255, 0.5);
+			text-shadow: none;
+		}
+
+		& a.tracy-action {
+			color: white !important;
+			opacity: 0;
+			font-size: .7em;
+			border-bottom: none !important;
+		}
+
+		&:hover a.tracy-action {
+			opacity: .6;
+		}
+
+		& a.tracy-action:hover {
+			opacity: 1;
+		}
+
+		& i {
+			color: #ffefa1;
+			font-style: normal;
+		}
+	}
+
+
+	/* source code */
+	& pre.tracy-code > div {
+		min-width: 100%;
+		float: left;
+		white-space: pre;
+	}
+
+	.tracy-code-comment {
+		color: rgba(0, 0, 0, 0.5);
+		font-style: italic;
+	}
+
+	.tracy-code-keyword {
+		color: #D24;
+		font-weight: bold;
+	}
+
+	.tracy-code-var {
+		font-weight: bold;
+	}
+
+	.tracy-line-highlight {
+		background: #CD1818;
+		color: white;
+		font-weight: bold;
+		font-style: normal;
+		display: block;
+		padding: 0 1ch;
+		margin: 0 -1ch -1lh;
+	}
+
+	.tracy-column-highlight {
+		display: inline-block;
+		backdrop-filter: grayscale(1);
+		margin: 0 -1px;
+		padding: 0 1px;
+	}
+
+	.tracy-line {
+		color: #9F9C7F;
+		font-weight: normal;
+		font-style: normal;
+	}
+
+	& a.tracy-editor {
+		color: inherit;
+		border-bottom: 1px dotted rgba(0, 0, 0, .3);
+		border-radius: 3px;
+
+		&:hover {
+			background: #0001;
+		}
+	}
+
+	& span[data-tracy-href] {
+		border-bottom: 1px dotted rgba(0, 0, 0, .3);
+	}
+
+	.tracy-dump-whitespace {
+		color: #0003;
+	}
+
+	.tracy-caused {
+		float: right;
+		padding: .3em calc(1.5 * var(--tracy-space));
+		background: #df8075;
+		border-radius: 0 0 0 8px;
+		white-space: nowrap;
+
+		& a {
+			color: white;
+		}
+	}
+
+	.tracy-callstack {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+	}
+
+	.tracy-callstack-file {
+		text-align: right;
+		padding-right: var(--tracy-space);
+		white-space: nowrap;
+		height: calc(1.5 * var(--tracy-space));
+	}
+
+	.tracy-callstack-callee {
+		white-space: nowrap;
+		height: calc(1.5 * var(--tracy-space));
+	}
+
+	.tracy-callstack-additional {
+		grid-column-start: 1;
+		grid-column-end: 3;
+	}
+
+	.tracy-callstack-additional:not(:last-child) {
+		margin-bottom: var(--tracy-space);
+	}
+
+	.tracy-callstack-args tr:first-child > * {
+		position: relative;
+	}
+
+	.tracy-callstack-args tr:first-child td:before {
+		position: absolute;
+		right: .3em;
+		content: 'may not be true';
+		opacity: .4;
+	}
+
+	.tracy-panel-fadein {
+		animation: tracy-panel-fadein .12s ease;
+	}
+
+	@keyframes tracy-panel-fadein {
+		0% {
+			opacity: 0;
+		}
+	}
+
+	.tracy-section--causedby {
+		flex-direction: column;
+		padding: 0;
+
+		&:not(.tracy-collapsed) {
+			display: flex;
+		}
+
+		& .tracy-section--error {
+			background: #cd1818a6;
+		}
+	}
+
+	.tracy-section--error + .tracy-section--stack {
+		margin-top: calc(1.5 * var(--tracy-space));
+	}
+
+
+	/* tabs */
+	.tracy-tab-bar {
+		display: flex;
+		list-style: none;
+		padding-left: 0;
+		margin: 0;
+		width: 100%;
+		font-size: 110%;
+
+		& > *:not(:first-child) {
+			margin-left: var(--tracy-space);
+		}
+
+		& a {
+			display: block;
+			padding: calc(.5 * var(--tracy-space)) var(--tracy-space);
+			margin: 0;
+			height: 100%;
+			box-sizing: border-box;
+			border-radius: 5px 5px 0 0;
+			text-decoration: none;
+			transition: all 0.1s;
+		}
+
+		& > .tracy-active a {
+			background: white;
+		}
+	}
+
+	.tracy-tab-panel {
+		border-top: 2px solid white;
+		padding-top: var(--tracy-space);
+		overflow: auto;
+	}
 }

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -2,16 +2,6 @@
  * This file is part of the Tracy (https://tracy.nette.org)
  */
 
-:root {
-	--tracy-space: 16px;
-}
-
-@media (max-width: 600px) {
-	:root {
-		--tracy-space: 8px;
-	}
-}
-
 html.tracy-bs-visible,
 html.tracy-bs-visible body {
 	display: block;
@@ -19,6 +9,7 @@ html.tracy-bs-visible body {
 }
 
 #tracy-bs {
+	--tracy-space: 16px;
 	font: 9pt/1.5 Verdana, sans-serif;
 	background: white;
 	color: #333;
@@ -28,6 +19,12 @@ html.tracy-bs-visible body {
 	top: 0;
 	width: 100%;
 	text-align: left;
+}
+
+@media (max-width: 600px) {
+	#tracy-bs {
+		--tracy-space: 8px;
+	}
 }
 
 #tracy-bs a {
@@ -92,7 +89,6 @@ html.tracy-bs-visible body {
 #tracy-bs h2 {
 	font-size: 14pt;
 	font-weight: normal;
-	margin-top: var(--tracy-space);
 }
 
 #tracy-bs h3 {
@@ -188,8 +184,7 @@ html.tracy-bs-visible body {
 
 
 #tracy-bs .tracy-section {
-	padding-left: calc(1.5 * var(--tracy-space));
-	padding-right: calc(1.5 * var(--tracy-space));
+	padding: var(--tracy-space);
 }
 
 #tracy-bs .tracy-section-panel {
@@ -216,11 +211,11 @@ html.tracy-bs-visible body {
 	background: #CD1818;
 	color: white;
 	font-size: 13pt;
-	padding-top: var(--tracy-space);
 }
 
 #tracy-bs .tracy-section--error h1 {
 	color: white;
+	margin: 0;
 }
 
 #tracy-bs .tracy-section--error::selection,
@@ -337,7 +332,6 @@ html.tracy-bs-visible body {
 #tracy-bs .tracy-callstack {
 	display: grid;
 	grid-template-columns: max-content 1fr;
-	margin-bottom: calc(.5 * var(--tracy-space));
 }
 
 #tracy-bs .tracy-callstack-file {

--- a/src/Tracy/BlueScreen/assets/bluescreen.css
+++ b/src/Tracy/BlueScreen/assets/bluescreen.css
@@ -67,15 +67,6 @@ html.tracy-bs-visible body {
 	display: none;
 }
 
-#tracy-bs p,
-#tracy-bs table,
-#tracy-bs pre,
-#tracy-bs h1,
-#tracy-bs h2,
-#tracy-bs h3 {
-	margin: 0 0 var(--tracy-space);
-}
-
 #tracy-bs h1 {
 	font-size: 15pt;
 	font-weight: normal;
@@ -189,8 +180,7 @@ html.tracy-bs-visible body {
 
 #tracy-bs .tracy-section-panel {
 	background: #F4F3F1;
-	padding: var(--tracy-space) var(--tracy-space) 0;
-	margin: 0 0 var(--tracy-space);
+	padding: var(--tracy-space);
 	border-radius: 8px;
 	box-shadow: inset 1px 1px 0px 0 #00000005;
 	overflow: hidden;
@@ -199,6 +189,10 @@ html.tracy-bs-visible body {
 #tracy-bs .outer, /* deprecated */
 #tracy-bs .tracy-pane {
 	overflow: auto;
+}
+
+#tracy-bs .tracy-pane:not(:last-child) {
+	margin-bottom: var(--tracy-space);
 }
 
 #tracy-bs.tracy-mac .tracy-pane {
@@ -215,7 +209,6 @@ html.tracy-bs-visible body {
 
 #tracy-bs .tracy-section--error h1 {
 	color: white;
-	margin: 0;
 }
 
 #tracy-bs .tracy-section--error::selection,
@@ -349,6 +342,10 @@ html.tracy-bs-visible body {
 #tracy-bs .tracy-callstack-additional {
 	grid-column-start: 1;
 	grid-column-end: 3;
+}
+
+#tracy-bs .tracy-callstack-additional:not(:last-child) {
+	margin-bottom: var(--tracy-space);
 }
 
 #tracy-bs .tracy-callstack-args tr:first-child > * {

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -235,6 +235,7 @@ class Debugger
 			'Bar/Bar',
 			'Bar/DefaultBarPanel',
 			'BlueScreen/BlueScreen',
+			'BlueScreen/CodeHighlighter',
 			'Dumper/Describer',
 			'Dumper/Dumper',
 			'Dumper/Exposer',

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -17,7 +17,7 @@ use ErrorException;
  */
 class Debugger
 {
-	public const Version = '2.10.3';
+	public const Version = '2.10.4';
 
 	/** server modes for Debugger::enable() */
 	public const

--- a/src/Tracy/Debugger/Debugger.php
+++ b/src/Tracy/Debugger/Debugger.php
@@ -17,7 +17,7 @@ use ErrorException;
  */
 class Debugger
 {
-	public const Version = '2.10.4';
+	public const Version = '3.0-dev';
 
 	/** server modes for Debugger::enable() */
 	public const

--- a/src/Tracy/Debugger/DeferredContent.php
+++ b/src/Tracy/Debugger/DeferredContent.php
@@ -147,7 +147,7 @@ final class DeferredContent
 	public function clean(): void
 	{
 		foreach ($this->sessionStorage->getData() as &$items) {
-			$items = array_slice((array) $items, -10, null, true);
+			$items = array_slice((array) $items, -10, null, preserve_keys: true);
 			$items = array_filter($items, fn($item) => isset($item['time']) && $item['time'] > time() - 60);
 		}
 	}

--- a/src/Tracy/Debugger/DevelopmentStrategy.php
+++ b/src/Tracy/Debugger/DevelopmentStrategy.php
@@ -54,7 +54,7 @@ final class DevelopmentStrategy
 		}
 
 		if ($logFile && !headers_sent()) {
-			header("X-Tracy-Error-Log: $logFile", false);
+			header("X-Tracy-Error-Log: $logFile", replace: false);
 		}
 
 		if (Helpers::detectColors()) {

--- a/src/Tracy/Debugger/DevelopmentStrategy.php
+++ b/src/Tracy/Debugger/DevelopmentStrategy.php
@@ -57,8 +57,8 @@ final class DevelopmentStrategy
 			header("X-Tracy-Error-Log: $logFile", replace: false);
 		}
 
-		if (Helpers::detectColors()) {
-			echo "\n\n" . $this->blueScreen->highlightPhpCli($exception->getFile(), $exception->getLine()) . "\n";
+		if (Helpers::detectColors() && @is_file($exception->getFile())) {
+			echo "\n\n" . CodeHighlighter::highlightPhpCli(file_get_contents($exception->getFile()), $exception->getLine()) . "\n";
 		}
 
 		echo "$exception\n" . ($logFile ? "\n(stored in $logFile)\n" : '');

--- a/src/Tracy/Dumper/Describer.php
+++ b/src/Tracy/Dumper/Describer.php
@@ -132,7 +132,7 @@ final class Describer
 				return $res;
 			} elseif ($depth && $this->maxItems && count($arr) > $this->maxItems) {
 				$value->length = count($arr);
-				$arr = array_slice($arr, 0, $this->maxItems, true);
+				$arr = array_slice($arr, 0, $this->maxItems, preserve_keys: true);
 			}
 
 			$items = &$value->items;
@@ -144,7 +144,7 @@ final class Describer
 			$res = new Value(Value::TypeArray, null, count($arr));
 			$res->depth = $depth;
 			$items = &$res->items;
-			$arr = array_slice($arr, 0, $this->maxItems, true);
+			$arr = array_slice($arr, 0, $this->maxItems, preserve_keys: true);
 		}
 
 		$items = [];

--- a/src/Tracy/Dumper/Exposer.php
+++ b/src/Tracy/Dumper/Exposer.php
@@ -142,7 +142,7 @@ final class Exposer
 
 	public static function exposeDOMNode(\DOMNode $obj, Value $value, Describer $describer): void
 	{
-		$props = preg_match_all('#^\s*\[([^\]]+)\] =>#m', print_r($obj, true), $tmp) ? $tmp[1] : [];
+		$props = preg_match_all('#^\s*\[([^\]]+)\] =>#m', print_r($obj, return: true), $tmp) ? $tmp[1] : [];
 		sort($props);
 		foreach ($props as $p) {
 			$describer->addPropertyTo($value, $p, $obj->$p, Value::PropertyPublic);

--- a/src/Tracy/Dumper/Renderer.php
+++ b/src/Tracy/Dumper/Renderer.php
@@ -115,48 +115,21 @@ final class Renderer
 
 	private function renderVar(mixed $value, int $depth = 0, string|int|null $keyType = null): string
 	{
-		switch (true) {
-			case $value === null:
-				return '<span class="tracy-dump-null">null</span>';
-
-			case is_bool($value):
-				return '<span class="tracy-dump-bool">' . ($value ? 'true' : 'false') . '</span>';
-
-			case is_int($value):
-				return '<span class="tracy-dump-number">' . $value . '</span>';
-
-			case is_float($value):
-				return '<span class="tracy-dump-number">' . self::jsonEncode($value) . '</span>';
-
-			case is_string($value):
-				return $this->renderString($value, $depth, $keyType);
-
-			case is_array($value):
-			case $value->type === Value::TypeArray:
-				return $this->renderArray($value, $depth);
-
-			case $value->type === Value::TypeRef:
-				return $this->renderVar($this->snapshot[$value->value], $depth, $keyType);
-
-			case $value->type === Value::TypeObject:
-				return $this->renderObject($value, $depth);
-
-			case $value->type === Value::TypeNumber:
-				return '<span class="tracy-dump-number">' . Helpers::escapeHtml($value->value) . '</span>';
-
-			case $value->type === Value::TypeText:
-				return '<span class="tracy-dump-virtual">' . Helpers::escapeHtml($value->value) . '</span>';
-
-			case $value->type === Value::TypeStringHtml:
-			case $value->type === Value::TypeBinaryHtml:
-				return $this->renderString($value, $depth, $keyType);
-
-			case $value->type === Value::TypeResource:
-				return $this->renderResource($value, $depth);
-
-			default:
-				throw new \Exception('Unknown type');
-		}
+		return match (true) {
+			$value === null => '<span class="tracy-dump-null">null</span>',
+			is_bool($value) => '<span class="tracy-dump-bool">' . ($value ? 'true' : 'false') . '</span>',
+			is_int($value) => '<span class="tracy-dump-number">' . $value . '</span>',
+			is_float($value) => '<span class="tracy-dump-number">' . self::jsonEncode($value) . '</span>',
+			is_string($value) => $this->renderString($value, $depth, $keyType),
+			is_array($value), $value->type === Value::TypeArray => $this->renderArray($value, $depth),
+			$value->type === Value::TypeRef => $this->renderVar($this->snapshot[$value->value], $depth, $keyType),
+			$value->type === Value::TypeObject => $this->renderObject($value, $depth),
+			$value->type === Value::TypeNumber => '<span class="tracy-dump-number">' . Helpers::escapeHtml($value->value) . '</span>',
+			$value->type === Value::TypeText => '<span class="tracy-dump-virtual">' . Helpers::escapeHtml($value->value) . '</span>',
+			$value->type === Value::TypeStringHtml, $value->type === Value::TypeBinaryHtml => $this->renderString($value, $depth, $keyType),
+			$value->type === Value::TypeResource => $this->renderResource($value, $depth),
+			default => throw new \Exception('Unknown type'),
+		};
 	}
 
 

--- a/src/Tracy/Dumper/Renderer.php
+++ b/src/Tracy/Dumper/Renderer.php
@@ -100,8 +100,8 @@ final class Renderer
 			$this->parents = $this->snapshot = $this->above = [];
 		}
 
-		$s = $colors ? self::htmlToAnsi($s, $colors) : $s;
-		$s = htmlspecialchars_decode(strip_tags($s), ENT_QUOTES | ENT_HTML5);
+		$s = $colors ? Helpers::htmlToAnsi($s, $colors) : Helpers::htmlToText($s);
+		$s = preg_replace('/\e\[0m( *)(?=\e)/', '$1', $s);
 		$s = str_replace('…', '...', $s);
 		$s .= substr($s, -1) === "\n" ? '' : "\n";
 
@@ -421,26 +421,5 @@ final class Renderer
 				ini_set('serialize_precision', $old);
 			}
 		}
-	}
-
-
-	private static function htmlToAnsi(string $s, array $colors): string
-	{
-		$stack = ['0'];
-		$s = preg_replace_callback(
-			'#<\w+(?: class="tracy-dump-(\w+)")?[^>]*>|</\w+>#',
-			function ($m) use ($colors, &$stack): string {
-				if ($m[0][1] === '/') {
-					array_pop($stack);
-				} else {
-					$stack[] = isset($m[1], $colors[$m[1]]) ? $colors[$m[1]] : '0';
-				}
-
-				return "\033[" . end($stack) . 'm';
-			},
-			$s,
-		);
-		$s = preg_replace('/\e\[0m(\n*)(?=\e)/', '$1', $s);
-		return $s;
 	}
 }

--- a/src/Tracy/Dumper/Renderer.php
+++ b/src/Tracy/Dumper/Renderer.php
@@ -101,7 +101,6 @@ final class Renderer
 		}
 
 		$s = $colors ? Helpers::htmlToAnsi($s, $colors) : Helpers::htmlToText($s);
-		$s = preg_replace('/\e\[0m( *)(?=\e)/', '$1', $s);
 		$s = str_replace('…', '...', $s);
 		$s .= substr($s, -1) === "\n" ? '' : "\n";
 

--- a/src/Tracy/Dumper/assets/dumper-dark.css
+++ b/src/Tracy/Dumper/assets/dumper-dark.css
@@ -2,144 +2,146 @@
  * This file is part of the Tracy (https://tracy.nette.org)
  */
 
-.tracy-dump.tracy-dark {
-	text-align: left;
-	color: #f8f8f2;
-	background: #29292e;
-	border-radius: 4px;
-	padding: 1em;
-	margin: 1em 0;
-	word-break: break-all;
-	white-space: pre-wrap;
-}
+.tracy-dark {
+	&.tracy-dump {
+		text-align: left;
+		color: #f8f8f2;
+		background: #29292e;
+		border-radius: 4px;
+		padding: 1em;
+		margin: 1em 0;
+		word-break: break-all;
+		white-space: pre-wrap;
+	}
 
-.tracy-dump.tracy-dark div {
-	padding-left: 2.5ex;
-}
+	&.tracy-dump div {
+		padding-left: 2.5ex;
+	}
 
-.tracy-dump.tracy-dark div div {
-	border-left: 1px solid rgba(255, 255, 255, .1);
-	margin-left: .5ex;
-}
+	&.tracy-dump div div {
+		border-left: 1px solid rgba(255, 255, 255, .1);
+		margin-left: .5ex;
+	}
 
-.tracy-dump.tracy-dark div div:hover {
-	border-left-color: rgba(255, 255, 255, .25);
-}
+	&.tracy-dump div div:hover {
+		border-left-color: rgba(255, 255, 255, .25);
+	}
 
-.tracy-dark .tracy-dump-location {
-	color: silver;
-	font-size: 80%;
-	text-decoration: none;
-	background: none;
-	opacity: .5;
-	float: right;
-	cursor: pointer;
-}
+	.tracy-dump-location {
+		color: silver;
+		font-size: 80%;
+		text-decoration: none;
+		background: none;
+		opacity: .5;
+		float: right;
+		cursor: pointer;
+	}
 
-.tracy-dark .tracy-dump-location:hover,
-.tracy-dark .tracy-dump-location:focus {
-	opacity: 1;
-}
+	.tracy-dump-location:hover,
+	.tracy-dump-location:focus {
+		opacity: 1;
+	}
 
-.tracy-dark .tracy-dump-array,
-.tracy-dark .tracy-dump-object {
-	color: #f69c2e;
-	user-select: text;
-}
+	.tracy-dump-array,
+	.tracy-dump-object {
+		color: #f69c2e;
+		user-select: text;
+	}
 
-.tracy-dark .tracy-dump-string {
-	color: #3cdfef;
-	white-space: break-spaces;
-}
+	.tracy-dump-string {
+		color: #3cdfef;
+		white-space: break-spaces;
+	}
 
-.tracy-dark div.tracy-dump-string {
-	position: relative;
-	padding-left: 3.5ex;
-}
+	& div.tracy-dump-string {
+		position: relative;
+		padding-left: 3.5ex;
+	}
 
-.tracy-dark .tracy-dump-lq {
-	margin-left: calc(-1ex - 1px);
-}
+	.tracy-dump-lq {
+		margin-left: calc(-1ex - 1px);
+	}
 
-.tracy-dark div.tracy-dump-string:before {
-	content: '';
-	position: absolute;
-	left: calc(3ex - 1px);
-	top: 1.5em;
-	bottom: 0;
-	border-left: 1px solid rgba(255, 255, 255, .1);
-}
+	& div.tracy-dump-string:before {
+		content: '';
+		position: absolute;
+		left: calc(3ex - 1px);
+		top: 1.5em;
+		bottom: 0;
+		border-left: 1px solid rgba(255, 255, 255, .1);
+	}
 
-.tracy-dark .tracy-dump-virtual span,
-.tracy-dark .tracy-dump-dynamic span,
-.tracy-dark .tracy-dump-string span {
-	color: rgba(255, 255, 255, 0.5);
-}
+	.tracy-dump-virtual span,
+	.tracy-dump-dynamic span,
+	.tracy-dump-string span {
+		color: rgba(255, 255, 255, 0.5);
+	}
 
-.tracy-dark .tracy-dump-virtual i,
-.tracy-dark .tracy-dump-dynamic i,
-.tracy-dark .tracy-dump-string i {
-	font-size: 80%;
-	font-style: normal;
-	color: rgba(255, 255, 255, 0.5);
-	user-select: none;
-}
+	.tracy-dump-virtual i,
+	.tracy-dump-dynamic i,
+	.tracy-dump-string i {
+		font-size: 80%;
+		font-style: normal;
+		color: rgba(255, 255, 255, 0.5);
+		user-select: none;
+	}
 
-.tracy-dark .tracy-dump-number {
-	color: #77d285;
-}
+	.tracy-dump-number {
+		color: #77d285;
+	}
 
-.tracy-dark .tracy-dump-null,
-.tracy-dark .tracy-dump-bool {
-	color: #f3cb44;
-}
+	.tracy-dump-null,
+	.tracy-dump-bool {
+		color: #f3cb44;
+	}
 
-.tracy-dark .tracy-dump-virtual {
-	font-style: italic;
-}
+	.tracy-dump-virtual {
+		font-style: italic;
+	}
 
-.tracy-dark .tracy-dump-public::after {
-	content: ' pub';
-}
+	.tracy-dump-public::after {
+		content: ' pub';
+	}
 
-.tracy-dark .tracy-dump-protected::after {
-	content: ' pro';
-}
+	.tracy-dump-protected::after {
+		content: ' pro';
+	}
 
-.tracy-dark .tracy-dump-private::after {
-	content: ' pri';
-}
+	.tracy-dump-private::after {
+		content: ' pri';
+	}
 
-.tracy-dark .tracy-dump-public::after,
-.tracy-dark .tracy-dump-protected::after,
-.tracy-dark .tracy-dump-private::after,
-.tracy-dark .tracy-dump-hash {
-	font-size: 85%;
-	color: rgba(255, 255, 255, 0.35);
-}
+	.tracy-dump-public::after,
+	.tracy-dump-protected::after,
+	.tracy-dump-private::after,
+	.tracy-dump-hash {
+		font-size: 85%;
+		color: rgba(255, 255, 255, 0.35);
+	}
 
-.tracy-dark .tracy-dump-indent {
-	display: none;
-}
+	.tracy-dump-indent {
+		display: none;
+	}
 
-.tracy-dark .tracy-dump-highlight {
-	background: #C22;
-	color: white;
-	border-radius: 2px;
-	padding: 0 2px;
-	margin: 0 -2px;
-}
+	.tracy-dump-highlight {
+		background: #C22;
+		color: white;
+		border-radius: 2px;
+		padding: 0 2px;
+		margin: 0 -2px;
+	}
 
-span[data-tracy-href] {
-	border-bottom: 1px dotted rgba(255, 255, 255, .2);
-}
+	span[data-tracy-href] {
+		border-bottom: 1px dotted rgba(255, 255, 255, .2);
+	}
 
-.tracy-dark .tracy-dump-flash {
-	animation: tracy-dump-flash .2s ease;
-}
+	.tracy-dump-flash {
+		animation: tracy-dump-flash .2s ease;
+	}
 
-@keyframes tracy-dump-flash {
-	0% {
-		background: #c0c0c033;
+	@keyframes tracy-dump-flash {
+		0% {
+			background: #c0c0c033;
+		}
 	}
 }

--- a/src/Tracy/Dumper/assets/dumper-light.css
+++ b/src/Tracy/Dumper/assets/dumper-light.css
@@ -2,144 +2,146 @@
  * This file is part of the Tracy (https://tracy.nette.org)
  */
 
-.tracy-dump.tracy-light {
-	text-align: left;
-	color: #444;
-	background: #fdf9e2;
-	border-radius: 4px;
-	padding: 1em;
-	margin: 1em 0;
-	word-break: break-all;
-	white-space: pre-wrap;
-}
+.tracy-light {
+	&.tracy-dump {
+		text-align: left;
+		color: #444;
+		background: #fdf9e2;
+		border-radius: 4px;
+		padding: 1em;
+		margin: 1em 0;
+		word-break: break-all;
+		white-space: pre-wrap;
+	}
 
-.tracy-dump.tracy-light div {
-	padding-left: 2.5ex;
-}
+	&.tracy-dump div {
+		padding-left: 2.5ex;
+	}
 
-.tracy-dump.tracy-light div div {
-	border-left: 1px solid rgba(0, 0, 0, .1);
-	margin-left: .5ex;
-}
+	&.tracy-dump div div {
+		border-left: 1px solid rgba(0, 0, 0, .1);
+		margin-left: .5ex;
+	}
 
-.tracy-dump.tracy-light div div:hover {
-	border-left-color: rgba(0, 0, 0, .25);
-}
+	&.tracy-dump div div:hover {
+		border-left-color: rgba(0, 0, 0, .25);
+	}
 
-.tracy-light .tracy-dump-location {
-	color: gray;
-	font-size: 80%;
-	text-decoration: none;
-	background: none;
-	opacity: .5;
-	float: right;
-	cursor: pointer;
-}
+	.tracy-dump-location {
+		color: gray;
+		font-size: 80%;
+		text-decoration: none;
+		background: none;
+		opacity: .5;
+		float: right;
+		cursor: pointer;
+	}
 
-.tracy-light .tracy-dump-location:hover,
-.tracy-light .tracy-dump-location:focus {
-	opacity: 1;
-}
+	.tracy-dump-location:hover,
+	.tracy-dump-location:focus {
+		opacity: 1;
+	}
 
-.tracy-light .tracy-dump-array,
-.tracy-light .tracy-dump-object {
-	color: #C22;
-	user-select: text;
-}
+	.tracy-dump-array,
+	.tracy-dump-object {
+		color: #C22;
+		user-select: text;
+	}
 
-.tracy-light .tracy-dump-string {
-	color: #35D;
-	white-space: break-spaces;
-}
+	.tracy-dump-string {
+		color: #35D;
+		white-space: break-spaces;
+	}
 
-.tracy-light div.tracy-dump-string {
-	position: relative;
-	padding-left: 3.5ex;
-}
+	& div.tracy-dump-string {
+		position: relative;
+		padding-left: 3.5ex;
+	}
 
-.tracy-light .tracy-dump-lq {
-	margin-left: calc(-1ex - 1px);
-}
+	.tracy-dump-lq {
+		margin-left: calc(-1ex - 1px);
+	}
 
-.tracy-light div.tracy-dump-string:before {
-	content: '';
-	position: absolute;
-	left: calc(3ex - 1px);
-	top: 1.5em;
-	bottom: 0;
-	border-left: 1px solid rgba(0, 0, 0, .1);
-}
+	& div.tracy-dump-string:before {
+		content: '';
+		position: absolute;
+		left: calc(3ex - 1px);
+		top: 1.5em;
+		bottom: 0;
+		border-left: 1px solid rgba(0, 0, 0, .1);
+	}
 
-.tracy-light .tracy-dump-virtual span,
-.tracy-light .tracy-dump-dynamic span,
-.tracy-light .tracy-dump-string span {
-	color: rgba(0, 0, 0, 0.5);
-}
+	.tracy-dump-virtual span,
+	.tracy-dump-dynamic span,
+	.tracy-dump-string span {
+		color: rgba(0, 0, 0, 0.5);
+	}
 
-.tracy-light .tracy-dump-virtual i,
-.tracy-light .tracy-dump-dynamic i,
-.tracy-light .tracy-dump-string i {
-	font-size: 80%;
-	font-style: normal;
-	color: rgba(0, 0, 0, 0.5);
-	user-select: none;
-}
+	.tracy-dump-virtual i,
+	.tracy-dump-dynamic i,
+	.tracy-dump-string i {
+		font-size: 80%;
+		font-style: normal;
+		color: rgba(0, 0, 0, 0.5);
+		user-select: none;
+	}
 
-.tracy-light .tracy-dump-number {
-	color: #090;
-}
+	.tracy-dump-number {
+		color: #090;
+	}
 
-.tracy-light .tracy-dump-null,
-.tracy-light .tracy-dump-bool {
-	color: #850;
-}
+	.tracy-dump-null,
+	.tracy-dump-bool {
+		color: #850;
+	}
 
-.tracy-light .tracy-dump-virtual {
-	font-style: italic;
-}
+	.tracy-dump-virtual {
+		font-style: italic;
+	}
 
-.tracy-light .tracy-dump-public::after {
-	content: ' pub';
-}
+	.tracy-dump-public::after {
+		content: ' pub';
+	}
 
-.tracy-light .tracy-dump-protected::after {
-	content: ' pro';
-}
+	.tracy-dump-protected::after {
+		content: ' pro';
+	}
 
-.tracy-light .tracy-dump-private::after {
-	content: ' pri';
-}
+	.tracy-dump-private::after {
+		content: ' pri';
+	}
 
-.tracy-light .tracy-dump-public::after,
-.tracy-light .tracy-dump-protected::after,
-.tracy-light .tracy-dump-private::after,
-.tracy-light .tracy-dump-hash {
-	font-size: 85%;
-	color: rgba(0, 0, 0, 0.35);
-}
+	.tracy-dump-public::after,
+	.tracy-dump-protected::after,
+	.tracy-dump-private::after,
+	.tracy-dump-hash {
+		font-size: 85%;
+		color: rgba(0, 0, 0, 0.35);
+	}
 
-.tracy-light .tracy-dump-indent {
-	display: none;
-}
+	.tracy-dump-indent {
+		display: none;
+	}
 
-.tracy-light .tracy-dump-highlight {
-	background: #C22;
-	color: white;
-	border-radius: 2px;
-	padding: 0 2px;
-	margin: 0 -2px;
-}
+	.tracy-dump-highlight {
+		background: #C22;
+		color: white;
+		border-radius: 2px;
+		padding: 0 2px;
+		margin: 0 -2px;
+	}
 
-span[data-tracy-href] {
-	border-bottom: 1px dotted rgba(0, 0, 0, .2);
-}
+	span[data-tracy-href] {
+		border-bottom: 1px dotted rgba(0, 0, 0, .2);
+	}
 
-.tracy-light .tracy-dump-flash {
-	animation: tracy-dump-flash .2s ease;
-}
+	.tracy-dump-flash {
+		animation: tracy-dump-flash .2s ease;
+	}
 
-@keyframes tracy-dump-flash {
-	0% {
-		background: #c0c0c033;
+	@keyframes tracy-dump-flash {
+		0% {
+			background: #c0c0c033;
+		}
 	}
 }

--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -479,17 +479,18 @@ class Helpers
 	{
 		$stack = ['0'];
 		$s = preg_replace_callback(
-			'#<\w+(?: (?:style|class)=["\'](?:tracy-dump-)?(.*?)["\'])?[^>]*>|</\w+>#',
+			'#<\w+(?: class=["\']tracy-(?:dump-)?([\w-]+)["\'])?[^>]*>|</\w+>#',
 			function ($m) use ($colors, &$stack): string {
 				if ($m[0][1] === '/') {
 					array_pop($stack);
 				} else {
 					$stack[] = isset($m[1], $colors[$m[1]]) ? $colors[$m[1]] : '0';
 				}
-				return "\e[0m\e[" . end($stack) . 'm';
+				return "\e[" . end($stack) . 'm';
 			},
 			$s,
 		);
+		$s = preg_replace('/\e\[0m( *)(?=\e)/', '$1', $s);
 		$s = self::htmlToText($s);
 		return $s;
 	}

--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -451,9 +451,9 @@ class Helpers
 
 
 	/** @internal */
-	public static function truncateString(string $s, int $len, bool $utf): string
+	public static function truncateString(string $s, int $len, bool $utf8): string
 	{
-		if (!$utf) {
+		if (!$utf8) {
 			return $len < 0 ? substr($s, $len) : substr($s, 0, $len);
 		} elseif (function_exists('mb_substr')) {
 			return $len < 0

--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -544,6 +544,7 @@ class Helpers
 	/** @internal */
 	public static function minifyCss(string $s): string
 	{
+		return $s;
 		$last = '';
 		return preg_replace_callback(
 			<<<'XX'

--- a/src/Tracy/Logger/Logger.php
+++ b/src/Tracy/Logger/Logger.php
@@ -15,23 +15,22 @@ namespace Tracy;
  */
 class Logger implements ILogger
 {
-	/** @var string|null name of the directory where errors should be logged */
-	public $directory;
+	/** name of the directory where errors should be logged */
+	public ?string $directory = null;
 
-	/** @var string|array|null email or emails to which send error notifications */
-	public $email;
+	/** email or emails to which send error notifications */
+	public string|array|null $email = null;
 
-	/** @var string|null sender of email notifications */
-	public $fromEmail;
+	/** sender of email notifications */
+	public ?string $fromEmail = null;
 
-	/** @var mixed interval for sending email is 2 days */
-	public $emailSnooze = '2 days';
+	/** interval for sending email is 2 days */
+	public mixed $emailSnooze = '2 days';
 
 	/** @var callable handler for sending emails */
 	public $mailer;
 
-	/** @var BlueScreen|null */
-	private $blueScreen;
+	private ?BlueScreen $blueScreen = null;
 
 
 	public function __construct(?string $directory, string|array|null $email = null, ?BlueScreen $blueScreen = null)
@@ -78,10 +77,7 @@ class Logger implements ILogger
 	}
 
 
-	/**
-	 * @param  mixed  $message
-	 */
-	public static function formatMessage($message): string
+	public static function formatMessage(mixed $message): string
 	{
 		if ($message instanceof \Throwable) {
 			foreach (Helpers::getExceptionChain($message) as $exception) {
@@ -101,10 +97,7 @@ class Logger implements ILogger
 	}
 
 
-	/**
-	 * @param  mixed  $message
-	 */
-	public static function formatLogLine($message, ?string $exceptionFile = null): string
+	public static function formatLogLine(mixed $message, ?string $exceptionFile = null): string
 	{
 		return implode(' ', [
 			date('[Y-m-d H-i-s]'),
@@ -152,10 +145,7 @@ class Logger implements ILogger
 	}
 
 
-	/**
-	 * @param  mixed  $message
-	 */
-	protected function sendEmail($message): void
+	protected function sendEmail(mixed $message): void
 	{
 		$snooze = is_numeric($this->emailSnooze)
 			? $this->emailSnooze
@@ -174,10 +164,9 @@ class Logger implements ILogger
 
 	/**
 	 * Default mailer.
-	 * @param  mixed  $message
 	 * @internal
 	 */
-	public function defaultMailer($message, string $email): void
+	public function defaultMailer(mixed $message, string $email): void
 	{
 		$host = preg_replace('#[^\w.-]+#', '', $_SERVER['SERVER_NAME'] ?? php_uname('n'));
 		$parts = str_replace(

--- a/src/Tracy/assets/reset.css
+++ b/src/Tracy/assets/reset.css
@@ -2,384 +2,385 @@
  * This file is part of the Tracy (https://tracy.nette.org)
  */
 
-tracy-div:not(a b),
-tracy-div:not(a b) * {
-	font: inherit;
-	line-height: inherit;
-	color: inherit;
-	background: transparent;
-	margin: 0;
-	padding: 0;
-	border: none;
-	text-align: inherit;
-	list-style: inherit;
-	opacity: 1;
-	border-radius: 0;
-	box-shadow: none;
-	text-shadow: none;
-	box-sizing: border-box;
-	text-decoration: none;
-	text-transform: inherit;
-	white-space: inherit;
-	float: none;
-	clear: none;
-	max-width: initial;
-	min-width: initial;
-	max-height: initial;
-	min-height: initial;
-}
+tracy-div:not(a b) {
+	:is(&, & *) {
+		font: inherit;
+		line-height: inherit;
+		color: inherit;
+		background: transparent;
+		margin: 0;
+		padding: 0;
+		border: none;
+		text-align: inherit;
+		list-style: inherit;
+		opacity: 1;
+		border-radius: 0;
+		box-shadow: none;
+		text-shadow: none;
+		box-sizing: border-box;
+		text-decoration: none;
+		text-transform: inherit;
+		white-space: inherit;
+		float: none;
+		clear: none;
+		max-width: initial;
+		min-width: initial;
+		max-height: initial;
+		min-height: initial;
+	}
 
-tracy-div:not(a b) *:hover {
-	color: inherit;
-	background: transparent;
-}
+	*:hover {
+		color: inherit;
+		background: transparent;
+	}
 
-tracy-div:not(a b) *:not(svg):not(img):not(table) {
-	width: initial;
-	height: initial;
-}
+	*:not(svg):not(img):not(table) {
+		width: initial;
+		height: initial;
+	}
 
-tracy-div:not(a b):before,
-tracy-div:not(a b):after,
-tracy-div:not(a b) *:before,
-tracy-div:not(a b) *:after {
-	all: unset;
-}
+	&:before,
+	&:after,
+	*:before,
+	*:after {
+		all: unset;
+	}
 
-tracy-div:not(a b) :is(
-	h1, h2, h3, h4, h5, h6,
-	p,
-	ol, ul, dl,
-	pre, table, hr,
-):where(:not(:last-child)) {
-	margin-bottom: var(--tracy-space);
-}
+	:is(
+		h1, h2, h3, h4, h5, h6,
+		p,
+		ol, ul, dl,
+		pre, table, hr,
+	):where(:not(:last-child)) {
+		margin-bottom: var(--tracy-space);
+	}
 
-tracy-div:not(a b) b,
-tracy-div:not(a b) strong {
-	font-weight: bold;
-}
+	& b,
+	& strong {
+		font-weight: bold;
+	}
 
-tracy-div:not(a b) small {
-	font-size: smaller;
-}
+	& small {
+		font-size: smaller;
+	}
 
-tracy-div:not(a b) i,
-tracy-div:not(a b) em {
-	font-style: italic;
-}
+	& i,
+	& em {
+		font-style: italic;
+	}
 
-tracy-div:not(a b) big {
-	font-size: larger;
-}
+	& big {
+		font-size: larger;
+	}
 
-tracy-div:not(a b) small,
-tracy-div:not(a b) sub,
-tracy-div:not(a b) sup {
-	font-size: smaller;
-}
+	& small,
+	& sub,
+	& sup {
+		font-size: smaller;
+	}
 
-tracy-div:not(a b) ins {
-	text-decoration: underline;
-}
+	& ins {
+		text-decoration: underline;
+	}
 
-tracy-div:not(a b) del {
-	text-decoration: line-through;
-}
+	& del {
+		text-decoration: line-through;
+	}
 
-tracy-div:not(a b) table {
-	border-collapse: collapse;
-}
+	& table {
+		border-collapse: collapse;
+	}
 
-tracy-div:not(a b) pre {
-	font-family: monospace;
-	white-space: pre;
-}
+	& pre {
+		font-family: monospace;
+		white-space: pre;
+	}
 
-tracy-div:not(a b) code,
-tracy-div:not(a b) kbd,
-tracy-div:not(a b) samp {
-	font-family: monospace;
-}
+	& code,
+	& kbd,
+	& samp {
+		font-family: monospace;
+	}
 
-tracy-div:not(a b) input {
-	background-color: white;
-	padding: 1px;
-	border: 1px solid;
-}
+	& input {
+		background-color: white;
+		padding: 1px;
+		border: 1px solid;
+	}
 
-tracy-div:not(a b) textarea {
-	background-color: white;
-	border: 1px solid;
-	padding: 2px;
-	white-space: pre-wrap;
-}
+	& textarea {
+		background-color: white;
+		border: 1px solid;
+		padding: 2px;
+		white-space: pre-wrap;
+	}
 
-tracy-div:not(a b) select {
-	border: 1px solid;
-	white-space: pre;
-}
+	& select {
+		border: 1px solid;
+		white-space: pre;
+	}
 
-tracy-div:not(a b) article,
-tracy-div:not(a b) aside,
-tracy-div:not(a b) details,
-tracy-div:not(a b) div,
-tracy-div:not(a b) figcaption,
-tracy-div:not(a b) footer,
-tracy-div:not(a b) form,
-tracy-div:not(a b) header,
-tracy-div:not(a b) hgroup,
-tracy-div:not(a b) main,
-tracy-div:not(a b) nav,
-tracy-div:not(a b) section,
-tracy-div:not(a b) summary,
-tracy-div:not(a b) pre,
-tracy-div:not(a b) p,
-tracy-div:not(a b) dl,
-tracy-div:not(a b) dd,
-tracy-div:not(a b) dt,
-tracy-div:not(a b) blockquote,
-tracy-div:not(a b) figure,
-tracy-div:not(a b) address,
-tracy-div:not(a b) h1,
-tracy-div:not(a b) h2,
-tracy-div:not(a b) h3,
-tracy-div:not(a b) h4,
-tracy-div:not(a b) h5,
-tracy-div:not(a b) h6,
-tracy-div:not(a b) ul,
-tracy-div:not(a b) ol,
-tracy-div:not(a b) li,
-tracy-div:not(a b) hr {
-	display: block;
-}
+	& article,
+	& aside,
+	& details,
+	& div,
+	& figcaption,
+	& footer,
+	& form,
+	& header,
+	& hgroup,
+	& main,
+	& nav,
+	& section,
+	& summary,
+	& pre,
+	& p,
+	& dl,
+	& dd,
+	& dt,
+	& blockquote,
+	& figure,
+	& address,
+	& h1,
+	& h2,
+	& h3,
+	& h4,
+	& h5,
+	& h6,
+	& ul,
+	& ol,
+	& li,
+	& hr {
+		display: block;
+	}
 
-tracy-div:not(a b) a,
-tracy-div:not(a b) b,
-tracy-div:not(a b) big,
-tracy-div:not(a b) code,
-tracy-div:not(a b) em,
-tracy-div:not(a b) i,
-tracy-div:not(a b) small,
-tracy-div:not(a b) span,
-tracy-div:not(a b) strong {
-	display: inline;
-}
+	& a,
+	& b,
+	& big,
+	& code,
+	& em,
+	& i,
+	& small,
+	& span,
+	& strong {
+		display: inline;
+	}
 
-tracy-div:not(a b) table {
-	display: table;
-}
+	& table {
+		display: table;
+	}
 
-tracy-div:not(a b) tr {
-	display: table-row;
-}
+	& tr {
+		display: table-row;
+	}
 
-tracy-div:not(a b) col {
-	display: table-column;
-}
+	& col {
+		display: table-column;
+	}
 
-tracy-div:not(a b) colgroup {
-	display: table-column-group;
-}
+	& colgroup {
+		display: table-column-group;
+	}
 
-tracy-div:not(a b) tbody {
-	display: table-row-group;
-}
+	& tbody {
+		display: table-row-group;
+	}
 
-tracy-div:not(a b) thead {
-	display: table-header-group;
-}
+	& thead {
+		display: table-header-group;
+	}
 
-tracy-div:not(a b) tfoot {
-	display: table-footer-group;
-}
+	& tfoot {
+		display: table-footer-group;
+	}
 
-tracy-div:not(a b) td {
-	display: table-cell;
-}
+	& td {
+		display: table-cell;
+	}
 
-tracy-div:not(a b) th {
-	display: table-cell;
-}
-
-
-
-/* TableSort */
-tracy-div:not(a b) .tracy-sortable > :first-child > tr:first-child > * {
-	position: relative;
-}
-
-tracy-div:not(a b) .tracy-sortable > :first-child > tr:first-child > *:hover:before {
-	position: absolute;
-	right: .3em;
-	content: "\21C5";
-	opacity: .4;
-	font-weight: normal;
-}
+	& th {
+		display: table-cell;
+	}
 
 
-/* dump */
-tracy-div:not(a b) .tracy-dump div {
-	padding-left: 3ex;
-}
 
-tracy-div:not(a b) .tracy-dump div div {
-	border-left: 1px solid rgba(0, 0, 0, .1);
-	margin-left: .5ex;
-}
+	/* TableSort */
+	.tracy-sortable > :first-child > tr:first-child > * {
+		position: relative;
+	}
 
-tracy-div:not(a b) .tracy-dump div div:hover {
-	border-left-color: rgba(0, 0, 0, .25);
-}
-
-tracy-div:not(a b) .tracy-dump {
-	background: #FDF5CE;
-	padding: .4em .7em;
-	border: 1px dotted silver;
-	overflow: auto;
-}
-
-tracy-div:not(a b) table .tracy-dump.tracy-dump { /* overwrite .tracy-dump.tracy-light etc. */
-	padding: 0;
-	margin: 0;
-	border: none;
-}
-
-tracy-div:not(a b) .tracy-dump-location {
-	color: gray;
-	font-size: 80%;
-	text-decoration: none;
-	background: none;
-	opacity: .5;
-	float: right;
-	cursor: pointer;
-}
-
-tracy-div:not(a b) .tracy-dump-location:hover,
-tracy-div:not(a b) .tracy-dump-location:focus {
-	color: gray;
-	background: none;
-	opacity: 1;
-}
-
-tracy-div:not(a b) .tracy-dump-array,
-tracy-div:not(a b) .tracy-dump-object {
-	color: #C22;
-}
-
-tracy-div:not(a b) .tracy-dump-string {
-	color: #35D;
-	white-space: break-spaces;
-}
-
-tracy-div:not(a b) div.tracy-dump-string {
-	position: relative;
-	padding-left: 3.5ex;
-}
-
-tracy-div:not(a b) .tracy-dump-lq {
-	margin-left: calc(-1ex - 1px);
-}
-
-tracy-div:not(a b) div.tracy-dump-string:before {
-	content: '';
-	position: absolute;
-	left: calc(3ex - 1px);
-	top: 1.5em;
-	bottom: 0;
-	border-left: 1px solid rgba(0, 0, 0, .1);
-}
-
-tracy-div:not(a b) .tracy-dump-virtual span,
-tracy-div:not(a b) .tracy-dump-dynamic span,
-tracy-div:not(a b) .tracy-dump-string span {
-	color: rgba(0, 0, 0, 0.5);
-}
-
-tracy-div:not(a b) .tracy-dump-virtual i,
-tracy-div:not(a b) .tracy-dump-dynamic i,
-tracy-div:not(a b) .tracy-dump-string i {
-	font-size: 80%;
-	font-style: normal;
-	color: rgba(0, 0, 0, 0.5);
-	user-select: none;
-}
-
-tracy-div:not(a b) .tracy-dump-number {
-	color: #090;
-}
-
-tracy-div:not(a b) .tracy-dump-null,
-tracy-div:not(a b) .tracy-dump-bool {
-	color: #850;
-}
-
-tracy-div:not(a b) .tracy-dump-virtual {
-	font-style: italic;
-}
-
-tracy-div:not(a b) .tracy-dump-public::after {
-	content: ' pub';
-}
-
-tracy-div:not(a b) .tracy-dump-protected::after {
-	content: ' pro';
-}
-
-tracy-div:not(a b) .tracy-dump-private::after {
-	content: ' pri';
-}
-
-tracy-div:not(a b) .tracy-dump-public::after,
-tracy-div:not(a b) .tracy-dump-protected::after,
-tracy-div:not(a b) .tracy-dump-private::after,
-tracy-div:not(a b) .tracy-dump-hash {
-	font-size: 85%;
-	color: rgba(0, 0, 0, 0.5);
-}
-
-tracy-div:not(a b) .tracy-dump-indent {
-	display: none;
-}
-
-tracy-div:not(a b) .tracy-dump-highlight {
-	background: #C22;
-	color: white;
-	border-radius: 2px;
-	padding: 0 2px;
-	margin: 0 -2px;
-}
-
-tracy-div:not(a b) span[data-tracy-href] {
-	border-bottom: 1px dotted rgba(0, 0, 0, .2);
-}
+	.tracy-sortable > :first-child > tr:first-child > *:hover:before {
+		position: absolute;
+		right: .3em;
+		content: "\21C5";
+		opacity: .4;
+		font-weight: normal;
+	}
 
 
-/* toggle */
-tracy-div:not(a b) .tracy-toggle:after {
-	content: '';
-	display: inline-block;
-	vertical-align: middle;
-	line-height: 0;
-	border-top: .6ex solid;
-	border-right: .6ex solid transparent;
-	border-left: .6ex solid transparent;
-	transform: scale(1, 1.5);
-	margin: 0 .2ex 0 .7ex;
-	transition: .1s transform;
-	opacity: .5;
-}
+	/* dump */
+	.tracy-dump div {
+		padding-left: 3ex;
+	}
 
-tracy-div:not(a b) .tracy-toggle.tracy-collapsed:after {
-	transform: rotate(-90deg) scale(1, 1.5) translate(.1ex, 0);
-}
+	.tracy-dump div div {
+		border-left: 1px solid rgba(0, 0, 0, .1);
+		margin-left: .5ex;
+	}
+
+	.tracy-dump div div:hover {
+		border-left-color: rgba(0, 0, 0, .25);
+	}
+
+	.tracy-dump {
+		background: #FDF5CE;
+		padding: .4em .7em;
+		border: 1px dotted silver;
+		overflow: auto;
+	}
+
+	& table .tracy-dump.tracy-dump { /* overwrite .tracy-dump.tracy-light etc. */
+		padding: 0;
+		margin: 0;
+		border: none;
+	}
+
+	.tracy-dump-location {
+		color: gray;
+		font-size: 80%;
+		text-decoration: none;
+		background: none;
+		opacity: .5;
+		float: right;
+		cursor: pointer;
+	}
+
+	.tracy-dump-location:hover,
+	.tracy-dump-location:focus {
+		color: gray;
+		background: none;
+		opacity: 1;
+	}
+
+	.tracy-dump-array,
+	.tracy-dump-object {
+		color: #C22;
+	}
+
+	.tracy-dump-string {
+		color: #35D;
+		white-space: break-spaces;
+	}
+
+	& div.tracy-dump-string {
+		position: relative;
+		padding-left: 3.5ex;
+	}
+
+	.tracy-dump-lq {
+		margin-left: calc(-1ex - 1px);
+	}
+
+	& div.tracy-dump-string:before {
+		content: '';
+		position: absolute;
+		left: calc(3ex - 1px);
+		top: 1.5em;
+		bottom: 0;
+		border-left: 1px solid rgba(0, 0, 0, .1);
+	}
+
+	.tracy-dump-virtual span,
+	.tracy-dump-dynamic span,
+	.tracy-dump-string span {
+		color: rgba(0, 0, 0, 0.5);
+	}
+
+	.tracy-dump-virtual i,
+	.tracy-dump-dynamic i,
+	.tracy-dump-string i {
+		font-size: 80%;
+		font-style: normal;
+		color: rgba(0, 0, 0, 0.5);
+		user-select: none;
+	}
+
+	.tracy-dump-number {
+		color: #090;
+	}
+
+	.tracy-dump-null,
+	.tracy-dump-bool {
+		color: #850;
+	}
+
+	.tracy-dump-virtual {
+		font-style: italic;
+	}
+
+	.tracy-dump-public::after {
+		content: ' pub';
+	}
+
+	.tracy-dump-protected::after {
+		content: ' pro';
+	}
+
+	.tracy-dump-private::after {
+		content: ' pri';
+	}
+
+	.tracy-dump-public::after,
+	.tracy-dump-protected::after,
+	.tracy-dump-private::after,
+	.tracy-dump-hash {
+		font-size: 85%;
+		color: rgba(0, 0, 0, 0.5);
+	}
+
+	.tracy-dump-indent {
+		display: none;
+	}
+
+	.tracy-dump-highlight {
+		background: #C22;
+		color: white;
+		border-radius: 2px;
+		padding: 0 2px;
+		margin: 0 -2px;
+	}
+
+	& span[data-tracy-href] {
+		border-bottom: 1px dotted rgba(0, 0, 0, .2);
+	}
 
 
-/* tabs */
-tracy-div:not(a b) .tracy-tab-label {
-	user-select: none;
-}
+	/* toggle */
+	.tracy-toggle:after {
+		content: '';
+		display: inline-block;
+		vertical-align: middle;
+		line-height: 0;
+		border-top: .6ex solid;
+		border-right: .6ex solid transparent;
+		border-left: .6ex solid transparent;
+		transform: scale(1, 1.5);
+		margin: 0 .2ex 0 .7ex;
+		transition: .1s transform;
+		opacity: .5;
+	}
 
-tracy-div:not(a b) .tracy-tab-panel:not(.tracy-active) {
-	display: none;
+	.tracy-toggle.tracy-collapsed:after {
+		transform: rotate(-90deg) scale(1, 1.5) translate(.1ex, 0);
+	}
+
+
+	/* tabs */
+	.tracy-tab-label {
+		user-select: none;
+	}
+
+	.tracy-tab-panel:not(.tracy-active) {
+		display: none;
+	}
 }

--- a/src/Tracy/assets/reset.css
+++ b/src/Tracy/assets/reset.css
@@ -46,6 +46,15 @@ tracy-div:not(a b) *:after {
 	all: unset;
 }
 
+tracy-div:not(a b) :is(
+	h1, h2, h3, h4, h5, h6,
+	p,
+	ol, ul, dl,
+	pre, table, hr,
+):where(:not(:last-child)) {
+	margin-bottom: var(--tracy-space);
+}
+
 tracy-div:not(a b) b,
 tracy-div:not(a b) strong {
 	font-weight: bold;

--- a/tests/Tracy/Debugger.dump().cli.phpt
+++ b/tests/Tracy/Debugger.dump().cli.phpt
@@ -23,7 +23,7 @@ test('production mode', function () {
 	Debugger::dump('sensitive data');
 	Assert::same('', ob_get_clean());
 
-	Assert::match("'forced'", Debugger::dump('forced', true));
+	Assert::match("'forced'", Debugger::dump('forced', return: true));
 });
 
 
@@ -34,7 +34,7 @@ test('development mode', function () {
 	Debugger::dump('sensitive data');
 	Assert::match('', ob_get_clean()); // is dumped to stout
 
-	Assert::match("'forced'", Debugger::dump('forced', true));
+	Assert::match("'forced'", Debugger::dump('forced', return: true));
 });
 
 

--- a/tests/Tracy/Debugger.dump().phpt
+++ b/tests/Tracy/Debugger.dump().phpt
@@ -26,7 +26,7 @@ test('production mode', function () {
 	Debugger::dump('sensitive data');
 	Assert::same('', ob_get_clean());
 
-	Assert::match("'forced'", Debugger::dump('forced', true));
+	Assert::match("'forced'", Debugger::dump('forced', return: true));
 });
 
 
@@ -38,7 +38,7 @@ test('development mode', function () {
 	Assert::match("'sensitive data'
 	", ob_get_clean());
 
-	Assert::match("'forced'", Debugger::dump('forced', true));
+	Assert::match("'forced'", Debugger::dump('forced', return: true));
 });
 
 

--- a/tests/Tracy/Dumper.keys.phpt
+++ b/tests/Tracy/Dumper.keys.phpt
@@ -90,4 +90,4 @@ Assert::equal([
 			[['string' => '&lt;a> &amp;amp;', 'length' => 9], 0, 3],
 		],
 	],
-], array_values(json_decode(explode("'", Dumper::formatSnapshotAttribute($snapshot))[1], true)));
+], array_values(json_decode(explode("'", Dumper::formatSnapshotAttribute($snapshot))[1], associative: true)));

--- a/tests/Tracy/Dumper.keysToHide.phpt
+++ b/tests/Tracy/Dumper.keysToHide.phpt
@@ -65,4 +65,4 @@ Assert::equal([
 			],
 		],
 	],
-], array_values(json_decode(explode("'", Dumper::formatSnapshotAttribute($snapshot))[1], true)));
+], array_values(json_decode(explode("'", Dumper::formatSnapshotAttribute($snapshot))[1], associative: true)));

--- a/tests/Tracy/Dumper.toHtml().live.phpt
+++ b/tests/Tracy/Dumper.toHtml().live.phpt
@@ -16,7 +16,7 @@ require __DIR__ . '/fixtures/DumpClass.php';
 
 function formatSnapshot(): array
 {
-	return json_decode(explode("'", Dumper::formatSnapshotAttribute(Dumper::$liveSnapshot))[1], true);
+	return json_decode(explode("'", Dumper::formatSnapshotAttribute(Dumper::$liveSnapshot))[1], associative: true);
 }
 
 

--- a/tests/Tracy/Dumper.toTerminal().phpt
+++ b/tests/Tracy/Dumper.toTerminal().phpt
@@ -18,13 +18,13 @@ Assert::match("\e[1;33mnull\e[0m", Dumper::toTerminal(null));
 
 Assert::match(
 	<<<XX
-		\e[1;31marray\e[0m (4)
-		\e[1;30m   \e[1;32m0\e[0m => \e[1;32m1
-		\e[1;30m   \e[1;32m1\e[0m => \e[1;36m\e[0m'\e[1;36mhello\e[0m'\e[1;36m
+		\e[1;31marray\e[0m (4)\e[0m
+		\e[1;30m   \e[1;32m0\e[0m => \e[1;32m1\e[0m
+		\e[1;30m   \e[1;32m1\e[0m => \e[1;36m\e[0m'\e[1;36mhello\e[0m'\e[1;36m\e[0m
 		\e[1;30m   \e[1;32m2\e[0m => \e[1;31marray\e[0m (0)
-		\e[1;30m   \e[1;32m3\e[0m => \e[1;31marray\e[0m (2)
-		\e[1;30m   |  \e[1;32m0\e[0m => \e[1;33mtrue
-		\e[1;30m   |  \e[1;32m1\e[0m => \e[1;33mnull
+		\e[1;30m   \e[1;32m3\e[0m => \e[1;31marray\e[0m (2)\e[0m
+		\e[1;30m   |  \e[1;32m0\e[0m => \e[1;33mtrue\e[0m
+		\e[1;30m   |  \e[1;32m1\e[0m => \e[1;33mnull\e[0m
 		\e[0m
 		XX,
 	Dumper::toTerminal([1, 'hello', [], [true, null]]),
@@ -39,18 +39,18 @@ $obj->{''} = 10;
 
 Assert::match(
 	<<<XX
-		\e[1;31mChild\e[0m \e[0m#%d%
-		\e[1;30m   \e[1;37mnew\e[0m: \e[1;32m7
-		\e[1;30m   \e[1;37m0\e[0m: \e[1;32m8
-		\e[1;30m   \e[1;37m1\e[0m: \e[1;32m9
-		\e[1;30m   \e[1;37m\e[0m'\e[1;37m\e[0m'\e[1;37m\e[0m: \e[1;32m10
-		\e[1;30m   \e[1;37mx\e[0m: \e[1;32m1
-		\e[1;30m   \e[1;37my\e[0m: \e[1;32m2
-		\e[1;30m   \e[1;37mz\e[0m: \e[1;32m3
-		\e[1;30m   \e[1;37mx2\e[0m: \e[1;32m4
-		\e[1;30m   \e[1;37my2\e[0m: \e[1;32m5
-		\e[1;30m   \e[1;37mz2\e[0m: \e[1;32m6
-		\e[1;30m   \e[1;37my\e[0m: \e[1;36m\e[0m'\e[1;36mhello\e[0m'\e[1;36m
+		\e[1;31mChild \e[0m#%d%\e[0m
+		\e[1;30m   \e[1;37mnew\e[0m: \e[1;32m7\e[0m
+		\e[1;30m   \e[1;37m0\e[0m: \e[1;32m8\e[0m
+		\e[1;30m   \e[1;37m1\e[0m: \e[1;32m9\e[0m
+		\e[1;30m   \e[1;37m\e[0m'\e[1;37m\e[0m'\e[1;37m\e[0m: \e[1;32m10\e[0m
+		\e[1;30m   \e[1;37mx\e[0m: \e[1;32m1\e[0m
+		\e[1;30m   \e[1;37my\e[0m: \e[1;32m2\e[0m
+		\e[1;30m   \e[1;37mz\e[0m: \e[1;32m3\e[0m
+		\e[1;30m   \e[1;37mx2\e[0m: \e[1;32m4\e[0m
+		\e[1;30m   \e[1;37my2\e[0m: \e[1;32m5\e[0m
+		\e[1;30m   \e[1;37mz2\e[0m: \e[1;32m6\e[0m
+		\e[1;30m   \e[1;37my\e[0m: \e[1;36m\e[0m'\e[1;36mhello\e[0m'\e[1;36m\e[0m
 		\e[0m
 		XX,
 	Dumper::toTerminal($obj),
@@ -61,10 +61,10 @@ $arr = (object) ['x' => 1, 'y' => 2];
 $arr->z = &$arr;
 Assert::match(
 	<<<XX
-		\e[1;31mstdClass\e[0m \e[0m#%d%
-		\e[1;30m   \e[1;37mx\e[0m: \e[1;32m1
-		\e[1;30m   \e[1;37my\e[0m: \e[1;32m2
-		\e[1;30m   \e[1;37mz\e[0m: \e[0m&1\e[0m \e[1;31mstdClass\e[0m \e[0m#%d%\e[0m \e[0mRECURSION
+		\e[1;31mstdClass \e[0m#%d%\e[0m
+		\e[1;30m   \e[1;37mx\e[0m: \e[1;32m1\e[0m
+		\e[1;30m   \e[1;37my\e[0m: \e[1;32m2\e[0m
+		\e[1;30m   \e[1;37mz\e[0m: \e[0m&1 \e[1;31mstdClass \e[0m#%d% \e[0mRECURSION\e[0m
 		\e[0m
 		XX,
 	Dumper::toTerminal($arr),

--- a/tests/Tracy/Helpers.encodeString().phpt
+++ b/tests/Tracy/Helpers.encodeString().phpt
@@ -28,5 +28,5 @@ Assert::same("utf <i>\\n</i>\n<i>\\r\\t</i>    <i>\\e\\x00</i> Iñtër", Helpers
 Assert::same('utf \n\r\t\xab Iñtër', Helpers::encodeString('utf \n\r\t\xab Iñtër'));
 Assert::same("binary <i>\\n</i>\n<i>\\r\\t</i>    <i>\\xA0</i> I<i>\\xC3\\xB1</i>t<i>\\xC3\\xAB</i>r", Helpers::encodeString("binary \n\r\t\xA0 Iñtër"));
 
-Assert::same("utf \n\r\t<i>\\e\\x00</i> Iñtër", Helpers::encodeString("utf \n\r\t\e\x00 Iñtër", null, false));
-Assert::same("binary \n\r\t<i>\\xA0</i> I<i>\\xC3\\xB1</i>t<i>\\xC3\\xAB</i>r", Helpers::encodeString("binary \n\r\t\xA0 Iñtër", null, false));
+Assert::same("utf \n\r\t<i>\\e\\x00</i> Iñtër", Helpers::encodeString("utf \n\r\t\e\x00 Iñtër", showWhitespaces: false));
+Assert::same("binary \n\r\t<i>\\xA0</i> I<i>\\xC3\\xB1</i>t<i>\\xC3\\xAB</i>r", Helpers::encodeString("binary \n\r\t\xA0 Iñtër", showWhitespaces: false));

--- a/tests/Tracy/Helpers.truncateString(().phpt
+++ b/tests/Tracy/Helpers.truncateString(().phpt
@@ -12,17 +12,17 @@ use Tracy\Helpers;
 require __DIR__ . '/../bootstrap.php';
 
 
-Assert::same('', Helpers::truncateString('', 1, true));
-Assert::same('h', Helpers::truncateString('hello', 1, true));
-Assert::same('hello', Helpers::truncateString('hello', 5, true));
-Assert::same('hello', Helpers::truncateString('hello', 6, true));
+Assert::same('', Helpers::truncateString('', 1, utf8: true));
+Assert::same('h', Helpers::truncateString('hello', 1, utf8: true));
+Assert::same('hello', Helpers::truncateString('hello', 5, utf8: true));
+Assert::same('hello', Helpers::truncateString('hello', 6, utf8: true));
 
-Assert::same('Iñtërnâtiônàlizætiøn', Helpers::truncateString('Iñtërnâtiônàlizætiøn', 20, true));
-Assert::same('Iñtër', Helpers::truncateString('Iñtërnâtiônàlizætiøn', 5, true));
+Assert::same('Iñtërnâtiônàlizætiøn', Helpers::truncateString('Iñtërnâtiônàlizætiøn', 20, utf8: true));
+Assert::same('Iñtër', Helpers::truncateString('Iñtërnâtiônàlizætiøn', 5, utf8: true));
 
-Assert::same("\x00", Helpers::truncateString("\x00\x01", 1, true));
-Assert::same("\x00\x01", Helpers::truncateString("\x00\x01", 5, true));
+Assert::same("\x00", Helpers::truncateString("\x00\x01", 1, utf8: true));
+Assert::same("\x00\x01", Helpers::truncateString("\x00\x01", 5, utf8: true));
 
-Assert::same('bad', Helpers::truncateString("bad\xff", 3, false));
-Assert::same("bad\xff", Helpers::truncateString("bad\xff", 4, false));
-Assert::same("bad\xff", Helpers::truncateString("bad\xff", 5, false));
+Assert::same('bad', Helpers::truncateString("bad\xff", 3, utf8: false));
+Assert::same("bad\xff", Helpers::truncateString("bad\xff", 4, utf8: false));
+Assert::same("bad\xff", Helpers::truncateString("bad\xff", 5, utf8: false));

--- a/tests/Tracy/expected/Debugger.exception.html.expect
+++ b/tests/Tracy/expected/Debugger.exception.html.expect
@@ -33,22 +33,22 @@
 
 	<div class="tracy-section-panel">
 		<p><b>File:</b> %a%</p>
-		<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>
+		<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span class='tracy-code-keyword'><span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
+<span class='tracy-line'>%d%:</span>    function </span>second<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>, </span><span class='tracy-code-var'>$arg2</span><span class='tracy-code-keyword'>)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line'>%d%:</span>        </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">([</span><span style="color: #000">1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">2</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">3</span><span style="color: #D24; font-weight: bold">]);
+<span class='tracy-line'>%d%:</span>        </span>third<span class='tracy-code-keyword'>([</span><span class='tracy-dump-number'>1</span><span class='tracy-code-keyword'>, </span><span class='tracy-dump-number'>2</span><span class='tracy-code-keyword'>, </span><span class='tracy-dump-number'>3</span><span class='tracy-code-keyword'>]);
 <span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
+<span class='tracy-line'>%d%:</span>    function </span>third<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>)
 <span class='tracy-line'>%d%:</span>    {
 </span><span class='tracy-line-highlight'>%d%:        throw new Exception('The my exception', 123);</span>
-<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+<span class='tracy-code-keyword'><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    </span><span style="color: #000">define</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'MY_CONST'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
-</span></span></code></div></pre>
+<span class='tracy-line'>%d%:</span>    </span>define<span class='tracy-code-keyword'>(</span><span class='tracy-dump-string'>'MY_CONST'</span><span class='tracy-code-keyword'>, </span><span class='tracy-dump-number'>123</span><span class='tracy-code-keyword'>);
+</span></code></div></pre>
 	</div>
 </section>
 
@@ -67,22 +67,22 @@
 		</div>
 
 		<div class="tracy-callstack-additional tracy-collapsed">
-			<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>
+			<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span class='tracy-code-keyword'><span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
+<span class='tracy-line'>%d%:</span>    function </span>first<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>, </span><span class='tracy-code-var'>$arg2</span><span class='tracy-code-keyword'>)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line'>%d%:</span>        </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">true</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">false</span><span style="color: #D24; font-weight: bold">);
+<span class='tracy-line'>%d%:</span>        </span>second<span class='tracy-code-keyword'>(</span>true<span class='tracy-code-keyword'>, </span>false<span class='tracy-code-keyword'>);
 <span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
+<span class='tracy-line'>%d%:</span>    function </span>second<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>, </span><span class='tracy-code-var'>$arg2</span><span class='tracy-code-keyword'>)
 <span class='tracy-line'>%d%:</span>    {
 </span><span class='tracy-line-highlight'>%d%:        third([1, 2, 3]);</span>
-<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+<span class='tracy-code-keyword'><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
-</span></span></code></div></pre>
+<span class='tracy-line'>%d%:</span>    function </span>third<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>)
+</span></code></div></pre>
 
 			<table class="tracy-callstack-args">
 <tr><th>$arg1</th><td><pre class="tracy-dump tracy-light" data-tracy-dump='[[0,1],[1,2],[2,3]]'></pre>
@@ -99,22 +99,22 @@
 		</div>
 
 		<div class="tracy-callstack-additional tracy-collapsed">
-			<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='tracy-line'>19:</span>
+			<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span class='tracy-code-keyword'><span class='tracy-line'>19:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    </span><span style="color: #000">Debugger</span><span style="color: #D24; font-weight: bold">::</span><span style="color: #000">$productionMode </span><span style="color: #D24; font-weight: bold">= </span><span style="color: #000">false</span><span style="color: #D24; font-weight: bold">;
-<span class='tracy-line'>%d%:</span>    </span><span style="color: #000">setHtmlMode</span><span style="color: #D24; font-weight: bold">();
+<span class='tracy-line'>%d%:</span>    </span>Debugger<span class='tracy-code-keyword'>::</span><span class='tracy-code-var'>$productionMode </span><span class='tracy-code-keyword'>= </span>false<span class='tracy-code-keyword'>;
+<span class='tracy-line'>%d%:</span>    </span>setHtmlMode<span class='tracy-code-keyword'>();
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    </span><span style="color: #000">Debugger</span><span style="color: #D24; font-weight: bold">::</span><span style="color: #000">enable</span><span style="color: #D24; font-weight: bold">();
+<span class='tracy-line'>%d%:</span>    </span>Debugger<span class='tracy-code-keyword'>::</span>enable<span class='tracy-code-keyword'>();
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
+<span class='tracy-line'>%d%:</span>    function </span>first<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>, </span><span class='tracy-code-var'>$arg2</span><span class='tracy-code-keyword'>)
 <span class='tracy-line'>%d%:</span>    {
 </span><span class='tracy-line-highlight'>%d%:        second(true, false);</span>
-<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+<span class='tracy-code-keyword'><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
-</span></span></code></div></pre>
+<span class='tracy-line'>%d%:</span>    function </span>second<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>, </span><span class='tracy-code-var'>$arg2</span><span class='tracy-code-keyword'>)
+</span></code></div></pre>
 
 			<table class="tracy-callstack-args">
 <tr><th>$arg1</th><td><pre class="tracy-dump tracy-light"><span class="tracy-dump-bool">true</span></pre>
@@ -133,19 +133,18 @@
 		</div>
 
 		<div class="tracy-callstack-additional tracy-collapsed">
-			<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span style="color: #06B"><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>
+			<pre title="Ctrl-Click to open in editor" data-tracy-href="%a%" class='tracy-code'><div><code><span class='tracy-code-keyword'><span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
+<span class='tracy-line'>%d%:</span>    function </span>third<span class='tracy-code-keyword'>(</span><span class='tracy-code-var'>$arg1</span><span class='tracy-code-keyword'>)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line'>%d%:</span>        throw new </span><span style="color: #000">Exception</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'The my exception'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
+<span class='tracy-line'>%d%:</span>        throw new </span>Exception<span class='tracy-code-keyword'>(</span><span class='tracy-dump-string'>'The my exception'</span><span class='tracy-code-keyword'>, </span><span class='tracy-dump-number'>123</span><span class='tracy-code-keyword'>);
 <span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
-<span class='tracy-line'>%d%:</span>    </span><span style="color: #000">define</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'MY_CONST'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
-<span class='tracy-line'>%d%:</span>    @</span><span style="color: #000">hex2bin</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'a'</span><span style="color: #D24; font-weight: bold">); </span><span style="color: #998; font-style: italic">// E_WARNING
+<span class='tracy-line'>%d%:</span>    </span>define<span class='tracy-code-keyword'>(</span><span class='tracy-dump-string'>'MY_CONST'</span><span class='tracy-code-keyword'>, </span><span class='tracy-dump-number'>123</span><span class='tracy-code-keyword'>);
+<span class='tracy-line'>%d%:</span>    @</span>hex2bin<span class='tracy-code-keyword'>(</span><span class='tracy-dump-string'>'a'</span><span class='tracy-code-keyword'>); </span><span class='tracy-code-comment'>// E_WARNING
 </span><span class='tracy-line-highlight'>%d%:    first(10, 'any string');</span>
-<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    </span>
-</span></code></div></pre>
+</code></div></pre>
 
 			<table class="tracy-callstack-args">
 <tr><th>$arg1</th><td><pre class="tracy-dump tracy-light"><span class="tracy-dump-number">10</span></pre>

--- a/tests/Tracy/expected/Debugger.exception.html.expect
+++ b/tests/Tracy/expected/Debugger.exception.html.expect
@@ -43,8 +43,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line-highlight'>%d%:        throw new Exception('The my exception', 123);</span>
-</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+</span><span class='tracy-line-highlight'>%d%:        throw new Exception('The my exception', 123);</span>
+<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    </span><span style="color: #000">define</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'MY_CONST'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
@@ -77,8 +77,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line-highlight'>%d%:        third([1, 2, 3]);</span>
-</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+</span><span class='tracy-line-highlight'>%d%:        third([1, 2, 3]);</span>
+<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
@@ -109,8 +109,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line-highlight'>%d%:        second(true, false);</span>
-</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+</span><span class='tracy-line-highlight'>%d%:        second(true, false);</span>
+<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
@@ -143,8 +143,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    </span><span style="color: #000">define</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'MY_CONST'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
 <span class='tracy-line'>%d%:</span>    @</span><span style="color: #000">hex2bin</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'a'</span><span style="color: #D24; font-weight: bold">); </span><span style="color: #998; font-style: italic">// E_WARNING
-<span class='tracy-line-highlight'>%d%:    first(10, 'any string');</span>
-</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    </span>
+</span><span class='tracy-line-highlight'>%d%:    first(10, 'any string');</span>
+<span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    </span>
 </span></code></div></pre>
 
 			<table class="tracy-callstack-args">

--- a/tests/Tracy/expected/Debugger.exception.html.expect
+++ b/tests/Tracy/expected/Debugger.exception.html.expect
@@ -43,8 +43,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line-highlight'>%d%:        throw new Exception('The my exception', 123);
-</span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+<span class='tracy-line-highlight'>%d%:        throw new Exception('The my exception', 123);</span>
+</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    </span><span style="color: #000">define</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'MY_CONST'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
@@ -77,8 +77,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line-highlight'>%d%:        third([1, 2, 3]);
-</span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+<span class='tracy-line-highlight'>%d%:        third([1, 2, 3]);</span>
+</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">third</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">)
@@ -109,8 +109,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">first</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
 <span class='tracy-line'>%d%:</span>    {
-<span class='tracy-line-highlight'>%d%:        second(true, false);
-</span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
+<span class='tracy-line-highlight'>%d%:        second(true, false);</span>
+</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    }
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    function </span><span style="color: #000">second</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #000">$arg1</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">$arg2</span><span style="color: #D24; font-weight: bold">)
@@ -143,8 +143,8 @@
 <span class='tracy-line'>%d%:</span>
 <span class='tracy-line'>%d%:</span>    </span><span style="color: #000">define</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'MY_CONST'</span><span style="color: #D24; font-weight: bold">, </span><span style="color: #000">123</span><span style="color: #D24; font-weight: bold">);
 <span class='tracy-line'>%d%:</span>    @</span><span style="color: #000">hex2bin</span><span style="color: #D24; font-weight: bold">(</span><span style="color: #080">'a'</span><span style="color: #D24; font-weight: bold">); </span><span style="color: #998; font-style: italic">// E_WARNING
-<span class='tracy-line-highlight'>%d%:    first(10, 'any string');
-</span></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    </span>
+<span class='tracy-line-highlight'>%d%:    first(10, 'any string');</span>
+</span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #000"></span><span style="color: #D24; font-weight: bold"></span><span style="color: #080"></span><span style="color: #D24; font-weight: bold"><span class='tracy-line'>%d%:</span>    </span>
 </span></code></div></pre>
 
 			<table class="tracy-callstack-args">

--- a/tools/open-in-editor/windows/install.cmd
+++ b/tools/open-in-editor/windows/install.cmd
@@ -7,3 +7,8 @@ if defined PROCESSOR_ARCHITEW6432 (set reg="%systemroot%\sysnative\reg.exe") els
 %reg% ADD HKCR\editor /v "URL Protocol" /d "" /f
 %reg% ADD HKCR\editor\shell\open\command /ve /d "wscript \"%~dp0open-editor.js\" \"%%1\"" /f
 %reg% ADD HKLM\SOFTWARE\Policies\Google\Chrome\URLWhitelist /v "123" /d "editor://*" /f
+
+:: Vivaldi - tested
+%reg% ADD HKLM\SOFTWARE\Policies\Vivaldi /v "AutoLaunchProtocolsFromOrigins" /d "[{\"allowed_origins\": [\"*\"],\"protocol\": \"editor\"}]" /t REG_SZ /f
+:: Chrome - should
+%reg% ADD HKLM\SOFTWARE\Policies\Google\Chrome /v "AutoLaunchProtocolsFromOrigins" /d "[{\"allowed_origins\": [\"*\"],\"protocol\": \"editor\"}]" /t REG_SZ /f


### PR DESCRIPTION
This allows you to open configured editor without prompt-message.
Primarily made for Vivaldi browser - tested OK
Chrome policies included too - not tested (should work according [doc](https://chromeenterprise.google/policies/?policy=AutoLaunchProtocolsFromOrigins)) 

- new feature Vivaldi support
- BC break? no

