### PR TITLE
error 500: Ensure text is legible with foreground colors

### DIFF
--- a/src/Tracy/Debugger/assets/error.500.phtml
+++ b/src/Tracy/Debugger/assets/error.500.phtml
@@ -21,8 +21,8 @@ namespace Tracy;
 <style>
 	#tracy-error { all: initial; position: absolute; top: 0; left: 0; right: 0; height: 70vh; min-height: 400px; display: flex; align-items: center; justify-content: center; z-index: 1000 }
 	#tracy-error div { all: initial; max-width: 550px; background: white; color: #333; display: block }
-	#tracy-error h1 { all: initial; font: bold 50px/1.1 sans-serif; display: block; margin: 40px }
-	#tracy-error p { all: initial; font: 20px/1.4 sans-serif; margin: 40px; display: block }
+	#tracy-error h1 { all: initial; background: white; color: #333; font: bold 50px/1.1 sans-serif; display: block; margin: 40px }
+	#tracy-error p { all: initial; background: white; color: #333; font: 20px/1.4 sans-serif; margin: 40px; display: block }
 	#tracy-error small { color: gray }
 	#tracy-error small span { color: silver }
 </style>


### PR DESCRIPTION
`all: initial` restores the color and background from the user agent style sheet. If user changes those, the text will become illegible.

- bug fix
- BC break? no

Here is how to change the text color in firefox: https://support.mozilla.org/cs/kb/zmena-pisma-barev-na-webovych-strankach#w_zmena-barvy-pisma

Here is how it looks like in my tweaked UI without this patch:

![borked foreground](https://github.com/nette/tracy/assets/705123/560f40b2-c96f-45cb-91b5-a541e26a6f6e)
