### PR TITLE
Drop obsolete E_STRICT error level

### DIFF
--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -130,7 +130,6 @@ class Helpers
 			E_USER_WARNING => 'User Warning',
 			E_NOTICE => 'Notice',
 			E_USER_NOTICE => 'User Notice',
-			E_STRICT => 'Strict standards',
 			E_DEPRECATED => 'Deprecated',
 			E_USER_DEPRECATED => 'User Deprecated',
 		];

--- a/tests/Tracy.Bridges/TracyExtension.services.phpt
+++ b/tests/Tracy.Bridges/TracyExtension.services.phpt
@@ -24,7 +24,7 @@ $compiler->addExtension('tracy', new TracyExtension);
 $compiler->addConfig([
 	'tracy' => [
 		'logSeverity' => E_USER_NOTICE,
-		'strictMode' => 'E_ALL & ~(E_STRICT|E_NOTICE)',
+		'strictMode' => 'E_ALL & ~(E_NOTICE)',
 		'scream' => ['E_DEPRECATED', 'E_USER_DEPRECATED'],
 		'keysToHide' => ['abc'],
 	],
@@ -49,7 +49,7 @@ Assert::same(Tracy\Debugger::getBlueScreen(), $container->getService('tracy.blue
 Assert::same(Tracy\Debugger::getBar(), $container->getService('tracy.bar'));
 
 Assert::same(E_USER_NOTICE, Tracy\Debugger::$logSeverity);
-Assert::same(E_ALL & ~(E_STRICT | E_NOTICE), Tracy\Debugger::$strictMode);
+Assert::same(E_ALL & ~(E_NOTICE), Tracy\Debugger::$strictMode);
 Assert::same(E_DEPRECATED | E_USER_DEPRECATED, Tracy\Debugger::$scream);
 Assert::contains('password', Tracy\Debugger::getBlueScreen()->keysToHide);
 Assert::contains('abc', Tracy\Debugger::getBlueScreen()->keysToHide);


### PR DESCRIPTION
- bug fix
- BC break? no

`E_STRICT` error level has not been used since PHP 8.0. PHP 8.4 started emitting deprecation warning on any usage of `E_STRICT` constant.

Tracy 2.10 requires min PHP 8.0, so this can be completely dropped.

See https://php.watch/versions/8.4/E_STRICT-deprecated