### PR TITLE
Fix "Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect"

### DIFF
--- a/src/Tracy/Helpers.php
+++ b/src/Tracy/Helpers.php
@@ -218,7 +218,6 @@ class Helpers
 
 		if ($message !== $e->getMessage()) {
 			$ref = new \ReflectionProperty($e, 'message');
-			$ref->setAccessible(true);
 			$ref->setValue($e, $message);
 		}
 


### PR DESCRIPTION
`setAccessible` is a no-op since 8.1 - see https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
