### PR TITLE
Proper dumper location when used together with Symfony VarDumper

### DIFF
--- a/src/Tracy/Dumper/Describer.php
+++ b/src/Tracy/Dumper/Describer.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Tracy\Dumper;
 
+use Symfony\Component\VarDumper\VarDumper as SymfonyVarDumper;
 use Tracy;
 use Tracy\Helpers;
 
@@ -323,10 +324,15 @@ final class Describer
 	private static function findLocation(): ?array
 	{
 		foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $item) {
-			if (isset($item['class']) && ($item['class'] === self::class || $item['class'] === Tracy\Dumper::class)) {
+			if (in_array($class ?? null, [self::class, Tracy\Dumper::class, SymfonyVarDumper::class])) {
 				$location = $item;
 				continue;
 			} elseif (isset($item['function'])) {
+				if (!isset($item['class']) && $item['function'] === 'dump') {
+					$location = $item;
+					continue;
+				}
+
 				try {
 					$reflection = isset($item['class'])
 						? new \ReflectionMethod($item['class'], $item['function'])


### PR DESCRIPTION
- bug fix / new feature? 🤷‍♂️
- BC break? no

Symfony VarDumper (a dependency of [many packages](https://packagist.org/packages/symfony/var-dumper/dependents?order_by=downloads), so it is often installed even when you don't want it) often takes over the dump function when both are installed.

It also conditionally [defines it](https://github.com/symfony/var-dumper/blob/7.3/Resources/functions/dump.php#L20), and unfortunately, it’s **impossible to control which definition gets included first**. Due to the same reason, it’s also not (in most cases) possible to define a custom function and let composer autoload it using `"autoload": {"files": [`. The only option is to require it manually before the Composer autoloader (which, in some tools like PHPUnit, is even required automatically first).

At least Symfony allows registering a custom handler using `VarDumper::setHandler(...)`, so it’s possible to redirect it to Tracy’s dump, which I prefer 🙂. There is a minor issue, though: the location resolved from the stack trace points to VarDumper instead.

If this got accepted, I can add the PR to docs too.