### PR TITLE
Limit BlueScreen agent argument dumps

### DIFF
--- a/src/Tracy/BlueScreen/BlueScreen.php
+++ b/src/Tracy/BlueScreen/BlueScreen.php
@@ -497,6 +497,8 @@ class BlueScreen
 	{
 		return fn($v, $k = null): string => Dumper::toText($v, [
 			Dumper::DEPTH => 3,
+			Dumper::TRUNCATE => $this->maxLength,
+			Dumper::ITEMS => $this->maxItems,
 			Dumper::SCRUBBER => $this->scrubber,
 			Dumper::KEYS_TO_HIDE => $this->keysToHide,
 		], $k);

--- a/src/Tracy/BlueScreen/dist/agent.phtml
+++ b/src/Tracy/BlueScreen/dist/agent.phtml
@@ -119,7 +119,7 @@ in ';
 				$argParts = [] /* pos 84:5 */;
 				foreach ($row['args'] as $k => $v) /* pos 85:5 */ {
 					$name = isset($params[$k]) && !$params[$k]->isVariadic() ? '$' . $params[$k]->getName() : '#' . $k /* pos 86:6 */;
-					$dump = rtrim($agentDump($v)) /* pos 87:6 */;
+					$dump = rtrim($agentDump($v, $name)) /* pos 87:6 */;
 					if (str_contains($dump, '
 ') || strlen($dump) > 50) /* pos 88:6 */ {
 						$allSimple = false /* pos 89:7 */;

--- a/tests/Tracy/BlueScreen.renderAgent().phpt
+++ b/tests/Tracy/BlueScreen.renderAgent().phpt
@@ -38,6 +38,29 @@ test('stack trace section with arguments', function () use ($blueScreen) {
 });
 
 
+test('stack trace argument dumps are limited', function () {
+	$blueScreen = new Tracy\BlueScreen;
+	$blueScreen->maxItems = 3;
+	$blueScreen->maxLength = 10;
+	$fn = function (array $items, string $text) {
+		throw new RuntimeException('Large arguments');
+	};
+	try {
+		$fn(range(1, 10), str_repeat('x', 50));
+	} catch (RuntimeException $e) {
+		$output = $blueScreen->renderAgent($e);
+	}
+
+	Assert::contains('$items = array (10)', $output);
+	Assert::contains('   0 => 1', $output);
+	Assert::contains('   1 => 2', $output);
+	Assert::contains('   2 => 3', $output);
+	Assert::contains('   ...', $output);
+	Assert::notContains('   3 => 4', $output);
+	Assert::contains('$text = \'xxxxxxxxxx ... xxxxxxxxxx\'', $output);
+});
+
+
 test('caused by section for chained exceptions', function () use ($blueScreen) {
 	$prev = new InvalidArgumentException('Root cause', 7);
 	$exception = new RuntimeException('Wrapper', 5, $prev);


### PR DESCRIPTION
 - bug fix / new feature? bug fix
  - BC break? no
  - doc PR: no

BlueScreen agent output currently dumps stack trace arguments without applying the same item and string limits that the HTML dump uses. In practice this can produce extremely large `.md` exception logs when a stack frame contains a large root array or object graph.

A real case was a hydration frame with a large result. The MD file grew to ~100 MB because the agent dump expanded the whole argument list.

This change fixes that in two parts:
- `BlueScreen::getAgentDumper()` now respects `maxLength` and `maxItems`
- stack trace arguments in `agent.phtml` are dumped with their argument name as the dumper key, so the existing `Dumper::ITEMS` limiting also applies to large root values
