### PR TITLE
Dumper: expose lazy object - skip virtual properties

### DIFF
--- a/src/Tracy/Dumper/Exposer.php
+++ b/src/Tracy/Dumper/Exposer.php
@@ -334,7 +334,7 @@ final class Exposer
 	{
 		$rc = new \ReflectionClass($obj);
 		foreach ($rc->getProperties() as $prop) {
-			if ($prop->isStatic() || $prop->isLazy($obj) || !$prop->isInitialized($obj)) {
+			if ($prop->isStatic() || $prop->isLazy($obj) || $prop->isVirtual() || !$prop->isInitialized($obj)) {
 				continue;
 			}
 

--- a/tests/Dumper/Dumper.toText().specials.lazyObject.virtual.phpt
+++ b/tests/Dumper/Dumper.toText().specials.lazyObject.virtual.phpt
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+/**
+ * Test: Tracy\Dumper::toText() & lazy object with virtual properties
+ * @phpversion 8.4
+ */
+
+use Tester\Assert;
+use Tracy\Dumper;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class LazyClassWithVirtualProp
+{
+	public function __construct(
+		public int $id,
+		public string $title,
+	) {
+	}
+
+	public string $virtual {
+		get => $this->title . '!';
+	}
+}
+
+$rc = new ReflectionClass(LazyClassWithVirtualProp::class);
+$ghost = $rc->newLazyGhost(function () {});
+
+// new ghost - virtual property should not appear (it has no backing value)
+Assert::match(
+	<<<'XX'
+		LazyClassWithVirtualProp (lazy) #%d%
+		XX,
+	Dumper::toText($ghost, [Dumper::DEPTH => 3]),
+);
+
+// preinitialized property - virtual property should still not appear
+$rc->getProperty('id')->setRawValueWithoutLazyInitialization($ghost, 123);
+
+Assert::match(
+	<<<'XX'
+		LazyClassWithVirtualProp (lazy) #%d%
+		   id: 123
+		XX,
+	Dumper::toText($ghost, [Dumper::DEPTH => 3]),
+);


### PR DESCRIPTION
- bug fix / new feature?   bug fix
- BC break? no
- doc PR: nette/docs#???  no

For uninitialized lazy ghost proxies, skips virtual properties (property hooks) because their getters can trigger proxy initialization and cause for example Doctrine identity map collisions during error logging.
