### PR TITLE
Bar: info panel gets OPcache status without the scripts table

### DIFF
--- a/src/Tracy/Bar/panels/info.panel.php
+++ b/src/Tracy/Bar/panels/info.panel.php
@@ -25,8 +25,10 @@ $ipFormatter = static function (?string $ip): ?string {
 	return $ip;
 };
 
-$opcache = function_exists('opcache_get_status') ? @opcache_get_status() : null; // @ can be restricted
-$cachedFiles = isset($opcache['scripts']) ? array_intersect(array_keys($opcache['scripts']), get_included_files()) : [];
+$opcache = function_exists('opcache_get_status') ? @opcache_get_status(false) : null; // @ can be restricted
+$cachedFiles = $opcache && function_exists('opcache_is_script_cached')
+	? array_filter(get_included_files(), fn(string $file): bool => @opcache_is_script_cached($file))
+	: [];
 $jit = $opcache['jit'] ?? null;
 
 $info = [


### PR DESCRIPTION
## Problem

`info.panel.php` calls `opcache_get_status()` with the default `$include_scripts = true`, which builds a 7-field entry for **every script in the opcode cache**. The cache belongs to the PHP process pool rather than the application, so on a machine serving several sites every vhost inflates the cost. That whole array is then used for a single membership test against `get_included_files()`.

Measured on PHP 8.5.9 with 1365 cached scripts, on a request that included 232 files:

```
opcache_get_status()       →  156.92 ms
opcache_get_status(false)  →    0.06 ms
```

In that app it was ~157 ms of a ~250 ms request — more than half the time spent rendering the entire Bar, inside a panel that is usually never opened. It grows with the size of the cache, so the busier the server, the worse it gets.

(For context, the `ReflectionClass` loop for `Classes + interfaces + traits` in the same file, which looks like the more obvious suspect, measured 0.1 ms.)

## Change

`opcache_is_script_cached()` answers exactly the question the row asks — "was *this* file served from the cache?" — with one hash lookup per included file, so `$include_scripts` can be `false`. `jit`, `memory_usage`, `interned_strings_usage` and `opcache_statistics` are all still returned, so the rest of the panel is untouched.

**The rendered row does not change.** Both implementations reported `100 % cached` (231 of 232 files) on the same request. To check they agree when something genuinely isn't cached, I included a file that had just been written, so `opcache.file_update_protection` skipped it: old and new code both reported `99.1 %`, and both identified the same two uncached files. The two path sets are directly comparable — `$opcache['scripts']` keys and `get_included_files()` are both resolved absolute paths.

Side effect: the row no longer depends on `$opcache['scripts']` existing at all, which was the subject of #271.

## Notes

- `opcache_is_script_cached()` has been available since PHP 5.5.11, well below Tracy's floor.
- Both functions are gated by the same `opcache.restrict_api` setting, so they succeed or fail together; the `$opcache &&` guard keeps the previous behaviour of showing `–` when the API is restricted or OPcache is off. The extra `function_exists()` only covers a build that has the status function but not the per-script one.
- No test added: the value is environment-dependent, so there is nothing stable to assert. Happy to add one if you'd like a particular shape.
- The timings above come from a single machine (macOS, PHP 8.5.9, 1365 cached scripts). The absolute figure scales with cache size; the ratio is the point.
